### PR TITLE
Add SentinelBot service and initial modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,155 @@
+# SentinelBot
+
+---
+
+## What is SentinelBot?
+
+SentinelBot is a QA testing service that uses **Claude AI** + **Playwright** to perform end-to-end testing on any web application. You give it a URL, a device to emulate, and optionally a persona (e.g., "elderly user", "impatient user") — it navigates your site, interacts with every element, and produces a structured bug report with:
+
+- Categorized issues (P0–P3 severity)
+- Screenshots at every step
+- Video recordings of the full session
+- Core Web Vitals performance metrics (LCP, CLS, TTFB, FCP)
+- WCAG 2.1 AA accessibility audit results
+- Root cause analysis linking similar issues across runs
+- Regression detection (comparing against previous runs)
+- Flaky test detection (automatic re-test of P0/P1 issues)
+
+Everything is persisted to **Supabase** and optionally pushed to **Slack** in real-time.
+
+---
+
+## Architecture Overview
+
+```mermaid
+graph TB
+    subgraph Client["Client"]
+        API_REQ["API Request<br/>(POST /api/test)"]
+        POLL["Poll Results<br/>(GET /api/runs/:id)"]
+    end
+
+    subgraph SentinelBot["SentinelBot Server (FastAPI :8502)"]
+        direction TB
+        SERVER["FastAPI Server"]
+        SCHEDULER["Continuous Scheduler<br/>(24/7 Monitoring)"]
+        
+        subgraph RunEngine["Run Engine"]
+            EXECUTE["_execute_run()"]
+            CALLBACKS["Callbacks<br/>(output, tool, API)"]
+            REALTIME["Real-Time Issue<br/>Detection"]
+        end
+    end
+
+    subgraph AI["Claude AI (Anthropic API)"]
+        LOOP["Agentic Sampling Loop"]
+        PROMPT["System Prompt<br/>+ Persona + Locale"]
+    end
+
+    subgraph Browser["Playwright Browser"]
+        PW_TOOL["PlaywrightComputerTool"]
+        ACTIONS["click, type, scroll,<br/>screenshot, wait"]
+        PERF["Performance Metrics<br/>(Core Web Vitals)"]
+        A11Y["Accessibility Audit<br/>(axe-core)"]
+    end
+
+    subgraph Database["Supabase"]
+        direction TB
+        DB_TABLES["Tables: runs, issues, evidence,<br/>run_logs, run_steps, perf_metrics,<br/>devices, networks, projects"]
+        STORAGE["Storage Buckets<br/>(screenshots, videos)"]
+    end
+
+    subgraph Notifications["Slack"]
+        SLACK["Slack Notifier"]
+    end
+
+    API_REQ --> SERVER
+    SERVER -->|run_id| API_REQ
+    POLL --> SERVER
+
+    SERVER -->|BackgroundTask| EXECUTE
+    SERVER -->|continuous=true| SCHEDULER
+    SCHEDULER -->|rotating combos| EXECUTE
+
+    EXECUTE --> LOOP
+    PROMPT --> LOOP
+    LOOP <-->|tool_use / tool_result| PW_TOOL
+
+    PW_TOOL --> ACTIONS
+    PW_TOOL --> PERF
+    PW_TOOL --> A11Y
+
+    CALLBACKS --> DB_TABLES
+    CALLBACKS --> STORAGE
+    EXECUTE --> DB_TABLES
+    EXECUTE --> STORAGE
+    SERVER --> DB_TABLES
+
+    EXECUTE --> SLACK
+    REALTIME --> SLACK
+```
+
+---
+
+
+## Personas
+
+SentinelBot can simulate different user behaviors to surface different types of issues:
+
+| Persona | Behavior |
+|---|---|
+| `first_time_user` | Unfamiliar with the app, confused by jargon, needs clear affordances |
+| `power_user` | Expects shortcuts, fast navigation, skips steps aggressively |
+| `elderly_user` | Needs large text, high contrast, 44x44px touch targets |
+| `non_technical_user` | Intimidated by technology, tries clicking non-interactive elements |
+| `impatient_user` | Clicks before pages load, double-clicks everything, submits partial forms |
+| `adversarial_user` | SQL injection, XSS payloads, emoji, extremely long text, boundary values |
+
+---
+
+## Environment Variables
+
+| Variable | Required | Description |
+|---|---|---|
+| `ANTHROPIC_API_KEY` | Yes | Claude API key |
+| `SUPABASE_URL` | Yes | Supabase project URL |
+| `SUPABASE_SERVICE_KEY` | Yes | Supabase service role key |
+| `SLACK_BOT_TOKEN` | No | Slack bot token for notifications |
+| `SENTINEL_VIDEO_DIR` | No | Temp directory for video files (default: `/tmp/sentinel_videos`) |
+
+---
+
+## Quick Start
+
+### Docker (Recommended)
+
+```bash
+docker build -f Dockerfile.sentinel -t sentinelbot:local .
+
+docker run --env-file .env -p 8502:8502 -it sentinelbot:local
+```
+
+### Local
+
+```bash
+pip install -r sentinel/requirements-sentinel.txt
+playwright install chromium
+
+uvicorn sentinel.sentinel_server:app --host 0.0.0.0 --port 8502
+```
+
+### API Docs
+
+Once the server is running, visit **http://localhost:8502/docs** for the interactive Swagger UI.
+
+---
+
+## Tech Stack
+
+| Component | Technology |
+|---|---|
+| Server | FastAPI + Uvicorn |
+| AI | Claude (Anthropic API) via agentic sampling loop |
+| Browser | Playwright (headless Chromium) |
+| Database | Supabase (PostgreSQL + Storage) |
+| Notifications | Slack API |
+| Container | Docker (Python 3.11 slim) |

--- a/sentinelbot/Dockerfile.sentinel
+++ b/sentinelbot/Dockerfile.sentinel
@@ -1,0 +1,42 @@
+FROM python:3.11-slim-bookworm
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+# ── System deps: only Playwright Chromium runtime libraries ──────────────
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    libnss3 \
+    libnspr4 \
+    libatk1.0-0 \
+    libatk-bridge2.0-0 \
+    libatspi2.0-0 \
+    libxcomposite1 \
+    libxdamage1 \
+    libxfixes3 \
+    libxrandr2 \
+    libgbm1 \
+    libpango-1.0-0 \
+    libcairo2 \
+    libasound2 \
+    libcups2 \
+    libdrm2 \
+    libxkbcommon0 \
+    fonts-noto-color-emoji \
+    fonts-liberation \
+    && rm -rf /var/lib/apt/lists/*
+
+# ── App user ─────────────────────────────────────────────────────────────
+RUN useradd -m -s /bin/bash sentinel
+USER sentinel
+WORKDIR /home/sentinel
+
+# ── Python deps ──────────────────────────────────────────────────────────
+COPY --chown=sentinel:sentinel sentinel/requirements-sentinel.txt /home/sentinel/requirements.txt
+RUN pip install --no-cache-dir -r requirements.txt && \
+    python -m playwright install chromium
+
+# ── App code ─────────────────────────────────────────────────────────────
+COPY --chown=sentinel:sentinel sentinel/ /home/sentinel/sentinel/
+COPY --chown=sentinel:sentinel image/entrypoint_sentinel.sh /home/sentinel/entrypoint.sh
+RUN chmod +x /home/sentinel/entrypoint.sh
+
+ENTRYPOINT ["./entrypoint.sh"]

--- a/sentinelbot/image/entrypoint_sentinel.sh
+++ b/sentinelbot/image/entrypoint_sentinel.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+set -e
+
+echo ""
+echo "🛡️  SentinelBot is starting..."
+echo "   API:    http://localhost:8502/docs"
+echo ""
+
+exec python -m uvicorn sentinel.sentinel_server:app \
+    --host 0.0.0.0 \
+    --port 8502 \
+    --log-level info

--- a/sentinelbot/sentinel/db/__init__.py
+++ b/sentinelbot/sentinel/db/__init__.py
@@ -1,0 +1,3 @@
+from .client import get_supabase
+
+__all__ = ["get_supabase"]

--- a/sentinelbot/sentinel/db/client.py
+++ b/sentinelbot/sentinel/db/client.py
@@ -1,0 +1,16 @@
+import os
+from functools import lru_cache
+
+from supabase import Client, create_client
+
+
+@lru_cache(maxsize=1)
+def get_supabase() -> Client:
+    """Return a cached Supabase client."""
+    url = os.environ.get("SUPABASE_URL", "")
+    key = os.environ.get("SUPABASE_SERVICE_KEY", "")
+    if not url or not key:
+        raise RuntimeError(
+            "SUPABASE_URL and SUPABASE_SERVICE_KEY environment variables are required"
+        )
+    return create_client(url, key)

--- a/sentinelbot/sentinel/db/db_devices.py
+++ b/sentinelbot/sentinel/db/db_devices.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from .client import get_supabase
+
+logger = logging.getLogger(__name__)
+
+
+def get_device_by_id(device_id: str) -> dict[str, Any]:
+    """Fetch a device row by UUID.
+
+    Returns dict with keys matching the DB columns:
+      id, name, platform, viewport_width, viewport_height,
+      device_scale_factor, user_agent, enabled, sort_order, created_at
+    """
+    sb = get_supabase()
+    result = sb.table("devices").select("*").eq("id", device_id).single().execute()
+    return result.data
+
+
+def get_network_by_id(network_id: str) -> dict[str, Any]:
+    """Fetch a network row by UUID.
+
+    Returns dict with keys:
+      id, name, latency_ms, download_kbps, upload_kbps, enabled, sort_order, created_at
+    """
+    sb = get_supabase()
+    result = sb.table("networks").select("*").eq("id", network_id).single().execute()
+    return result.data
+
+
+def list_devices(enabled_only: bool = True) -> list[dict[str, Any]]:
+    """List all devices, optionally filtered to enabled ones."""
+    sb = get_supabase()
+    query = sb.table("devices").select("*").order("sort_order")
+    if enabled_only:
+        query = query.eq("enabled", True)
+    result = query.execute()
+    return result.data
+
+
+def list_networks(enabled_only: bool = True) -> list[dict[str, Any]]:
+    """List all networks, optionally filtered to enabled ones."""
+    sb = get_supabase()
+    query = sb.table("networks").select("*").order("sort_order")
+    if enabled_only:
+        query = query.eq("enabled", True)
+    result = query.execute()
+    return result.data
+
+
+def device_to_playwright_profile(device: dict[str, Any]) -> dict[str, Any]:
+    """Convert a DB device row into a Playwright-compatible device profile dict.
+
+    This replaces the hardcoded DEVICE_PROFILES in playwright_tool.py.
+    """
+    is_mobile = device.get("platform", "").lower() in ("ios", "android", "mobile")
+    return {
+        "viewport": {
+            "width": device["viewport_width"],
+            "height": device["viewport_height"],
+        },
+        "user_agent": device.get("user_agent") or "",
+        "device_scale_factor": float(device.get("device_scale_factor", 1)),
+        "is_mobile": is_mobile,
+        "has_touch": is_mobile,
+    }
+
+
+def network_to_throttle_profile(network: dict[str, Any]) -> dict[str, Any]:
+    """Convert a DB network row into a CDP network-throttle dict.
+
+    Returns an empty dict for no-throttle (latency=0, download/upload unlimited),
+    matching the existing NETWORK_PROFILES["wifi"] == {} convention.
+    """
+    lat = network.get("latency_ms", 0)
+    down = network.get("download_kbps", 0)
+    up = network.get("upload_kbps", 0)
+
+    # Treat zero-latency + high-bandwidth as "no throttle"
+    if lat == 0 and down == 0 and up == 0:
+        return {}
+
+    return {
+        "offline": False,
+        "download_throughput": (down * 1024) // 8 if down else -1,
+        "upload_throughput": (up * 1024) // 8 if up else -1,
+        "latency": lat,
+    }

--- a/sentinelbot/sentinel/db/db_evidence.py
+++ b/sentinelbot/sentinel/db/db_evidence.py
@@ -1,0 +1,136 @@
+from __future__ import annotations
+
+import base64
+import logging
+import os
+from typing import Any
+
+from .client import get_supabase
+
+logger = logging.getLogger(__name__)
+
+SCREENSHOT_BUCKET = "evidence-screenshots"
+VIDEO_BUCKET = "evidence-videos"
+
+
+def ensure_buckets_exist() -> None:
+    """Create storage buckets if they don't already exist."""
+    sb = get_supabase()
+    existing = {b.name for b in sb.storage.list_buckets()}
+    for bucket in (SCREENSHOT_BUCKET, VIDEO_BUCKET):
+        if bucket not in existing:
+            sb.storage.create_bucket(bucket, options={"public": True})
+            logger.info(f"Created storage bucket: {bucket}")
+
+
+def upload_screenshot(
+    *,
+    run_id: str,
+    step: int,
+    base64_image: str,
+    issue_id: str | None = None,
+    label: str | None = None,
+) -> dict[str, Any]:
+    """Decode a base64 PNG, upload to Supabase Storage, and insert an evidence row.
+
+    Storage path: {run_id}/step_{step:03d}.png
+    Returns the evidence row.
+    """
+    sb = get_supabase()
+    image_bytes = base64.b64decode(base64_image)
+    storage_path = f"{run_id}/step_{step:03d}.png"
+
+    # Upload to bucket
+    sb.storage.from_(SCREENSHOT_BUCKET).upload(
+        path=storage_path,
+        file=image_bytes,
+        file_options={"content-type": "image/png", "upsert": "true"},
+    )
+
+    # Insert evidence record
+    row: dict[str, Any] = {
+        "run_id": run_id,
+        "type": "screenshot",
+        "storage_path": storage_path,
+        "label": label or f"Step {step}",
+    }
+    if issue_id:
+        row["issue_id"] = issue_id
+
+    result = sb.table("evidence").insert(row).execute()
+    return result.data[0]
+
+
+def upload_video(
+    *,
+    run_id: str,
+    local_path: str,
+    label: str | None = None,
+) -> dict[str, Any] | None:
+    """Upload a video file to Supabase Storage and insert an evidence row.
+
+    Storage path: {run_id}/{filename}
+    Returns the evidence row, or None if the file doesn't exist.
+    """
+    if not os.path.exists(local_path):
+        logger.warning(f"Video file not found: {local_path}")
+        return None
+
+    sb = get_supabase()
+    filename = os.path.basename(local_path)
+    storage_path = f"{run_id}/{filename}"
+
+    with open(local_path, "rb") as f:
+        video_bytes = f.read()
+
+    sb.storage.from_(VIDEO_BUCKET).upload(
+        path=storage_path,
+        file=video_bytes,
+        file_options={"content-type": "video/webm", "upsert": "true"},
+    )
+
+    row = {
+        "run_id": run_id,
+        "type": "video",
+        "storage_path": storage_path,
+        "label": label or "Recording",
+    }
+    result = sb.table("evidence").insert(row).execute()
+    return result.data[0]
+
+
+def link_evidence_to_issue(evidence_id: str, issue_id: str) -> None:
+    """Set the issue_id on an existing evidence row."""
+    sb = get_supabase()
+    sb.table("evidence").update({"issue_id": issue_id}).eq("id", evidence_id).execute()
+
+
+def get_evidence_for_run(run_id: str) -> list[dict[str, Any]]:
+    """List all evidence (screenshots + videos) for a run."""
+    sb = get_supabase()
+    result = (
+        sb.table("evidence")
+        .select("*")
+        .eq("run_id", run_id)
+        .order("created_at")
+        .execute()
+    )
+    return result.data
+
+
+def get_screenshot_url(storage_path: str, expires_in: int = 3600) -> str:
+    """Generate a signed URL for a screenshot in Supabase Storage."""
+    sb = get_supabase()
+    result = sb.storage.from_(SCREENSHOT_BUCKET).create_signed_url(
+        storage_path, expires_in
+    )
+    return result.get("signedURL", "")
+
+
+def get_video_url(storage_path: str, expires_in: int = 3600) -> str:
+    """Generate a signed URL for a video in Supabase Storage."""
+    sb = get_supabase()
+    result = sb.storage.from_(VIDEO_BUCKET).create_signed_url(
+        storage_path, expires_in
+    )
+    return result.get("signedURL", "")

--- a/sentinelbot/sentinel/db/db_issues.py
+++ b/sentinelbot/sentinel/db/db_issues.py
@@ -1,0 +1,269 @@
+from __future__ import annotations
+
+import logging
+import re
+from typing import Any
+
+from .client import get_supabase
+
+logger = logging.getLogger(__name__)
+
+
+def create_issue(
+    *,
+    project_id: str,
+    title: str,
+    description: str | None = None,
+    severity: str = "P2",
+    category: str | None = None,
+    run_id: str | None = None,
+    slack_user_id: str | None = None,
+) -> dict[str, Any]:
+    """Insert a new issue and return the full record.
+
+    severity: P0 | P1 | P2 | P3
+    category: backend | frontend | ux | performance | integration
+    slack_user_id: Slack user ID of the assigned owner
+    """
+    sb = get_supabase()
+    row: dict[str, Any] = {
+        "project_id": project_id,
+        "title": title,
+        "severity": severity,
+        "status": "assigned",
+    }
+    if run_id:
+        row["run_id"] = run_id
+    if description:
+        row["description"] = description
+    if slack_user_id:
+        row["slack_user_id"] = slack_user_id
+    if category:
+        # Map our prompt categories to DB categories
+        category_map = {
+            "functional": "frontend",
+            "visual": "ux",
+            "performance": "performance",
+            "accessibility": "ux",
+            "mobile": "frontend",
+            "regression": "regression",
+            "flaky": "flaky",
+            "backend": "backend",
+            "frontend": "frontend",
+            "ux": "ux",
+            "integration": "integration",
+        }
+        row["category"] = category_map.get(category, "frontend")
+
+    result = sb.table("issues").insert(row).execute()
+    return result.data[0]
+
+
+def link_issue_to_run(issue_id: str, run_id: str) -> None:
+    """Create an issue_runs junction record."""
+    sb = get_supabase()
+    sb.table("issue_runs").insert({
+        "issue_id": issue_id,
+        "run_id": run_id,
+    }).execute()
+
+
+def get_issues_for_run(run_id: str) -> list[dict[str, Any]]:
+    """Fetch all issues linked to a run via issue_runs."""
+    sb = get_supabase()
+    result = (
+        sb.table("issue_runs")
+        .select("issues(*)")
+        .eq("run_id", run_id)
+        .execute()
+    )
+    return [row["issues"] for row in result.data if row.get("issues")]
+
+
+def get_issues_for_project(
+    project_id: str,
+    status: str | None = None,
+) -> list[dict[str, Any]]:
+    """List issues for a project, optionally filtered by status."""
+    sb = get_supabase()
+    query = (
+        sb.table("issues")
+        .select("*")
+        .eq("project_id", project_id)
+        .order("created_at", desc=True)
+    )
+    if status:
+        query = query.eq("status", status)
+    result = query.execute()
+    return result.data
+
+
+# ── Root Cause Intelligence ─────────────────────────────────────────────
+
+
+def _tokenize(text: str) -> set[str]:
+    """Simple tokenizer: lowercase, split on non-alphanumeric, remove stopwords."""
+    STOPWORDS = {
+        "the", "a", "an", "is", "are", "was", "were", "be", "been", "being",
+        "have", "has", "had", "do", "does", "did", "will", "would", "shall",
+        "should", "may", "might", "must", "can", "could", "to", "of", "in",
+        "for", "on", "with", "at", "by", "from", "as", "into", "through",
+        "during", "before", "after", "above", "below", "between", "out",
+        "off", "over", "under", "again", "further", "then", "once", "and",
+        "but", "or", "nor", "not", "no", "so", "than", "too", "very",
+        "just", "that", "this", "it", "its", "i", "me", "my", "we", "our",
+    }
+    words = set(re.findall(r"[a-z0-9]+", text.lower()))
+    return words - STOPWORDS
+
+
+def _jaccard_similarity(a: set[str], b: set[str]) -> float:
+    """Jaccard similarity between two token sets."""
+    if not a or not b:
+        return 0.0
+    intersection = a & b
+    union = a | b
+    return len(intersection) / len(union)
+
+
+def find_similar_issues(
+    project_id: str,
+    title: str,
+    description: str | None = None,
+    threshold: float = 0.35,
+    max_results: int = 5,
+    exclude_issue_id: str | None = None,
+) -> list[dict[str, Any]]:
+    """Find existing issues similar to a new one using token-based similarity.
+
+    Returns a list of dicts with the issue data plus a `similarity_score` field,
+    sorted by descending similarity.
+
+    Args:
+        project_id: Scope similarity to the same project
+        title: Title of the new issue
+        description: Description of the new issue
+        threshold: Minimum similarity score (0.0 to 1.0)
+        max_results: Maximum number of similar issues to return
+        exclude_issue_id: Skip this issue (useful when checking after creation)
+    """
+    sb = get_supabase()
+
+    # Fetch recent issues for the same project
+    result = (
+        sb.table("issues")
+        .select("*")
+        .eq("project_id", project_id)
+        .order("created_at", desc=True)
+        .limit(200)
+        .execute()
+    )
+    existing = result.data
+
+    if not existing:
+        return []
+
+    # Build token set for the new issue
+    new_text = title + " " + (description or "")
+    new_tokens = _tokenize(new_text)
+
+    if not new_tokens:
+        return []
+
+    # Score each existing issue
+    scored: list[tuple[float, dict[str, Any]]] = []
+    for issue in existing:
+        if exclude_issue_id and issue["id"] == exclude_issue_id:
+            continue
+
+        existing_text = issue.get("title", "") + " " + (issue.get("description") or "")
+        existing_tokens = _tokenize(existing_text)
+        score = _jaccard_similarity(new_tokens, existing_tokens)
+
+        if score >= threshold:
+            scored.append((score, issue))
+
+    # Sort by score descending
+    scored.sort(key=lambda x: x[0], reverse=True)
+
+    results = []
+    for score, issue in scored[:max_results]:
+        results.append({
+            **issue,
+            "similarity_score": round(score, 3),
+        })
+
+    return results
+
+
+def get_issue_frequency(
+    project_id: str,
+    title_pattern: str | None = None,
+    days: int = 7,
+) -> list[dict[str, Any]]:
+    """Get issue frequency counts for trend analysis.
+
+    Groups issues by title similarity to detect recurring problems.
+    Returns [{title, count, severities, first_seen, last_seen}].
+    """
+    sb = get_supabase()
+    from datetime import datetime, timedelta, timezone
+
+    cutoff = (datetime.now(timezone.utc) - timedelta(days=days)).isoformat()
+
+    result = (
+        sb.table("issues")
+        .select("*")
+        .eq("project_id", project_id)
+        .gte("created_at", cutoff)
+        .order("created_at", desc=True)
+        .execute()
+    )
+
+    if not result.data:
+        return []
+
+    # Group by tokenized title similarity
+    groups: list[dict[str, Any]] = []
+    assigned: set[str] = set()
+
+    for issue in result.data:
+        if issue["id"] in assigned:
+            continue
+
+        tokens = _tokenize(issue["title"])
+        group = {
+            "representative_title": issue["title"],
+            "issues": [issue],
+            "severities": {issue["severity"]},
+            "first_seen": issue["created_at"],
+            "last_seen": issue["created_at"],
+        }
+        assigned.add(issue["id"])
+
+        # Find similar issues
+        for other in result.data:
+            if other["id"] in assigned:
+                continue
+            other_tokens = _tokenize(other["title"])
+            if _jaccard_similarity(tokens, other_tokens) >= 0.4:
+                group["issues"].append(other)
+                group["severities"].add(other["severity"])
+                assigned.add(other["id"])
+                if other["created_at"] < group["first_seen"]:
+                    group["first_seen"] = other["created_at"]
+                if other["created_at"] > group["last_seen"]:
+                    group["last_seen"] = other["created_at"]
+
+        groups.append({
+            "title": group["representative_title"],
+            "count": len(group["issues"]),
+            "severities": sorted(group["severities"]),
+            "first_seen": group["first_seen"],
+            "last_seen": group["last_seen"],
+            "issue_ids": [i["id"] for i in group["issues"]],
+        })
+
+    # Sort by count descending
+    groups.sort(key=lambda g: g["count"], reverse=True)
+    return groups

--- a/sentinelbot/sentinel/db/db_logs.py
+++ b/sentinelbot/sentinel/db/db_logs.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+import logging
+from datetime import datetime, timezone
+from typing import Any
+
+from .client import get_supabase
+
+logger = logging.getLogger(__name__)
+
+
+def insert_log(
+    *,
+    run_id: str,
+    level: str,          # info | warn | error | debug
+    event_type: str,     # e.g. "run_start", "api_call", "tool_result"
+    message: str | None = None,
+    payload: dict | None = None,
+) -> dict[str, Any]:
+    """Append a structured log entry for a run."""
+    sb = get_supabase()
+    row: dict[str, Any] = {
+        "run_id": run_id,
+        "ts": datetime.now(timezone.utc).isoformat(),
+        "level": level,
+        "event_type": event_type,
+    }
+    if message:
+        row["message"] = message
+    if payload:
+        row["payload"] = payload
+
+    result = sb.table("run_logs").insert(row).execute()
+    return result.data[0] if result.data else {}
+
+
+def insert_step(
+    *,
+    run_id: str,
+    step_index: int,
+    action_type: str | None = None,
+    description: str | None = None,
+    duration_ms: int | None = None,
+) -> dict[str, Any]:
+    """Record a single run step (tool call)."""
+    sb = get_supabase()
+    row: dict[str, Any] = {
+        "run_id": run_id,
+        "step_index": step_index,
+    }
+    if action_type:
+        row["action_type"] = action_type
+    if description:
+        row["description"] = description
+    if duration_ms is not None:
+        row["duration_ms"] = duration_ms
+
+    result = sb.table("run_steps").insert(row).execute()
+    return result.data[0] if result.data else {}
+
+
+def get_logs_for_run(run_id: str) -> list[dict[str, Any]]:
+    """Fetch all log entries for a run, ordered by timestamp."""
+    sb = get_supabase()
+    result = (
+        sb.table("run_logs")
+        .select("*")
+        .eq("run_id", run_id)
+        .order("ts")
+        .execute()
+    )
+    return result.data
+
+
+def get_steps_for_run(run_id: str) -> list[dict[str, Any]]:
+    """Fetch all steps for a run, ordered by step_index."""
+    sb = get_supabase()
+    result = (
+        sb.table("run_steps")
+        .select("*")
+        .eq("run_id", run_id)
+        .order("step_index")
+        .execute()
+    )
+    return result.data

--- a/sentinelbot/sentinel/db/db_perf.py
+++ b/sentinelbot/sentinel/db/db_perf.py
@@ -1,0 +1,112 @@
+"""Performance metrics persistence for Core Web Vitals and resource timing."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from .client import get_supabase
+
+logger = logging.getLogger(__name__)
+
+
+def insert_perf_metrics(
+    *,
+    run_id: str,
+    url: str,
+    lcp_ms: float | None = None,
+    cls: float | None = None,
+    ttfb_ms: float | None = None,
+    fcp_ms: float | None = None,
+    dom_content_loaded_ms: float | None = None,
+    resource_count: int | None = None,
+    total_transfer_kb: float | None = None,
+    step: int | None = None,
+) -> dict[str, Any]:
+    """Insert a performance metrics row for a page load within a run.
+
+    Collects Core Web Vitals (LCP, CLS, TTFB, FCP) + resource stats.
+
+    Args:
+        run_id: The run that captured these metrics
+        url: The page URL where metrics were collected
+        lcp_ms: Largest Contentful Paint (milliseconds)
+        cls: Cumulative Layout Shift (unitless score)
+        ttfb_ms: Time to First Byte (milliseconds)
+        fcp_ms: First Contentful Paint (milliseconds)
+        dom_content_loaded_ms: DOMContentLoaded event time (milliseconds)
+        resource_count: Number of resources loaded
+        total_transfer_kb: Total transfer size in KB
+        step: The step number where metrics were collected
+    """
+    sb = get_supabase()
+    row: dict[str, Any] = {
+        "run_id": run_id,
+        "url": url,
+    }
+    if lcp_ms is not None:
+        row["lcp_ms"] = round(lcp_ms, 2)
+    if cls is not None:
+        row["cls"] = round(cls, 4)
+    if ttfb_ms is not None:
+        row["ttfb_ms"] = round(ttfb_ms, 2)
+    if fcp_ms is not None:
+        row["fcp_ms"] = round(fcp_ms, 2)
+    if dom_content_loaded_ms is not None:
+        row["dom_content_loaded_ms"] = round(dom_content_loaded_ms, 2)
+    if resource_count is not None:
+        row["resource_count"] = resource_count
+    if total_transfer_kb is not None:
+        row["total_transfer_kb"] = round(total_transfer_kb, 2)
+    if step is not None:
+        row["step"] = step
+
+    try:
+        result = sb.table("performance_metrics").insert(row).execute()
+        return result.data[0]
+    except Exception as e:
+        logger.warning(f"Failed to insert perf metrics for run {run_id}: {e}")
+        return row
+
+
+def get_perf_metrics_for_run(run_id: str) -> list[dict[str, Any]]:
+    """Get all performance metrics collected during a run."""
+    sb = get_supabase()
+    result = (
+        sb.table("performance_metrics")
+        .select("*")
+        .eq("run_id", run_id)
+        .order("created_at")
+        .execute()
+    )
+    return result.data
+
+
+def get_perf_trends(
+    project_id: str,
+    url_pattern: str | None = None,
+    days: int = 7,
+    limit: int = 100,
+) -> list[dict[str, Any]]:
+    """Get performance metric trends for a project over time.
+
+    Joins with runs to filter by project_id and date range.
+    Returns metrics sorted by collection time.
+    """
+    sb = get_supabase()
+    from datetime import datetime, timedelta, timezone
+
+    cutoff = (datetime.now(timezone.utc) - timedelta(days=days)).isoformat()
+
+    # Query performance_metrics joined with runs
+    query = (
+        sb.table("performance_metrics")
+        .select("*, runs!inner(project_id, device_id, network_id, locale, started_at)")
+        .eq("runs.project_id", project_id)
+        .gte("runs.started_at", cutoff)
+        .order("created_at", desc=True)
+        .limit(limit)
+    )
+
+    result = query.execute()
+    return result.data

--- a/sentinelbot/sentinel/db/db_runs.py
+++ b/sentinelbot/sentinel/db/db_runs.py
@@ -1,0 +1,132 @@
+from __future__ import annotations
+
+import logging
+from datetime import datetime, timezone
+from typing import Any
+
+from .client import get_supabase
+
+logger = logging.getLogger(__name__)
+
+
+def create_run(
+    *,
+    project_id: str,
+    device_id: str,
+    network_id: str,
+    locale: str = "en-US",
+    persona: str | None = None,
+) -> dict[str, Any]:
+    """Insert a new run row and return the full record."""
+    sb = get_supabase()
+    row = {
+        "project_id": project_id,
+        "device_id": device_id,
+        "network_id": network_id,
+        "status": "running",
+        "locale": locale,
+        "persona": persona,
+        "started_at": datetime.now(timezone.utc).isoformat(),
+    }
+    result = sb.table("runs").insert(row).execute()
+    return result.data[0]
+
+
+def update_run_completed(
+    run_id: str,
+    *,
+    result: str,  # "no_issues" | "issue_found" | "crash"
+    duration_ms: int,
+) -> dict[str, Any]:
+    """Mark a run as completed."""
+    sb = get_supabase()
+    row = {
+        "status": "completed",
+        "result": result,
+        "finished_at": datetime.now(timezone.utc).isoformat(),
+        "duration_ms": duration_ms,
+    }
+    res = sb.table("runs").update(row).eq("id", run_id).execute()
+    return res.data[0] if res.data else {}
+
+
+def update_run_failed(
+    run_id: str,
+    *,
+    duration_ms: int,
+) -> dict[str, Any]:
+    """Mark a run as failed."""
+    sb = get_supabase()
+    row = {
+        "status": "failed",
+        "result": "crash",
+        "finished_at": datetime.now(timezone.utc).isoformat(),
+        "duration_ms": duration_ms,
+    }
+    res = sb.table("runs").update(row).eq("id", run_id).execute()
+    return res.data[0] if res.data else {}
+
+
+def get_run(run_id: str) -> dict[str, Any] | None:
+    """Fetch a single run by ID, including joined device/network names."""
+    sb = get_supabase()
+    result = (
+        sb.table("runs")
+        .select("*, devices(name, platform, viewport_width, viewport_height), networks(name, latency_ms)")
+        .eq("id", run_id)
+        .single()
+        .execute()
+    )
+    return result.data
+
+
+def list_runs(project_id: str | None = None, limit: int = 50) -> list[dict[str, Any]]:
+    """List recent runs, optionally filtered by project."""
+    sb = get_supabase()
+    query = (
+        sb.table("runs")
+        .select("*, devices(name), networks(name)")
+        .order("started_at", desc=True)
+        .limit(limit)
+    )
+    if project_id:
+        query = query.eq("project_id", project_id)
+    result = query.execute()
+    return result.data
+
+
+def get_previous_run(
+    *,
+    project_id: str,
+    device_id: str,
+    network_id: str,
+    exclude_run_id: str,
+) -> dict[str, Any] | None:
+    """Find the most recent completed run for the same project/device/network combo.
+
+    Used for cross-run regression detection — comparing the current run's
+    results against the previous run to find regressions.
+
+    Args:
+        project_id: Project to scope the search
+        device_id: Must match same device
+        network_id: Must match same network
+        exclude_run_id: Skip this run (the current one)
+
+    Returns:
+        The previous run row, or None if no previous run exists.
+    """
+    sb = get_supabase()
+    result = (
+        sb.table("runs")
+        .select("*")
+        .eq("project_id", project_id)
+        .eq("device_id", device_id)
+        .eq("network_id", network_id)
+        .eq("status", "completed")
+        .neq("id", exclude_run_id)
+        .order("started_at", desc=True)
+        .limit(1)
+        .execute()
+    )
+    return result.data[0] if result.data else None

--- a/sentinelbot/sentinel/loop.py
+++ b/sentinelbot/sentinel/loop.py
@@ -1,0 +1,337 @@
+import platform
+from collections.abc import Callable
+from datetime import datetime
+from enum import StrEnum
+from typing import Any, cast
+
+import httpx
+from anthropic import (
+    Anthropic,
+    AnthropicBedrock,
+    AnthropicVertex,
+    APIError,
+    APIResponseValidationError,
+    APIStatusError,
+)
+from anthropic.types.beta import (
+    BetaCacheControlEphemeralParam,
+    BetaContentBlockParam,
+    BetaImageBlockParam,
+    BetaMessage,
+    BetaMessageParam,
+    BetaTextBlock,
+    BetaTextBlockParam,
+    BetaToolResultBlockParam,
+    BetaToolUseBlockParam,
+)
+
+from .tools import (
+    TOOL_GROUPS_BY_VERSION,
+    ToolCollection,
+    ToolResult,
+    ToolVersion,
+)
+
+PROMPT_CACHING_BETA_FLAG = "prompt-caching-2024-07-31"
+
+
+class APIProvider(StrEnum):
+    ANTHROPIC = "anthropic"
+    BEDROCK = "bedrock"
+    VERTEX = "vertex"
+
+
+# This system prompt is optimized for the Docker environment in this repository and
+# specific tool combinations enabled.
+# We encourage modifying this system prompt to ensure the model has context for the
+# environment it is running in, and to provide any additional information that may be
+# helpful for the task at hand.
+SYSTEM_PROMPT = f"""<SYSTEM_CAPABILITY>
+* You are utilising an Ubuntu virtual machine using {platform.machine()} architecture with internet access.
+* You can feel free to install Ubuntu applications with your bash tool. Use curl instead of wget.
+* To open firefox, please just click on the firefox icon.  Note, firefox-esr is what is installed on your system.
+* Using bash tool you can start GUI applications, but you need to set export DISPLAY=:1 and use a subshell. For example "(DISPLAY=:1 xterm &)". GUI apps run with bash tool will appear within your desktop environment, but they may take some time to appear. Take a screenshot to confirm it did.
+* When using your bash tool with commands that are expected to output very large quantities of text, redirect into a tmp file and use str_replace_based_edit_tool or `grep -n -B <lines before> -A <lines after> <query> <filename>` to confirm output.
+* When viewing a page it can be helpful to zoom out so that you can see everything on the page.  Either that, or make sure you scroll down to see everything before deciding something isn't available.
+* When using your computer function calls, they take a while to run and send back to you.  Where possible/feasible, try to chain multiple of these calls all into one function calls request.
+* The current date is {datetime.today().strftime("%A, %B %-d, %Y")}.
+</SYSTEM_CAPABILITY>
+
+<IMPORTANT>
+* When using Firefox, if a startup wizard appears, IGNORE IT.  Do not even click "skip this step".  Instead, click on the address bar where it says "Search or enter address", and enter the appropriate search term or URL there.
+* If the item you are looking at is a pdf, if after taking a single screenshot of the pdf it seems that you want to read the entire document instead of trying to continue to read the pdf from your screenshots + navigation, determine the URL, use curl to download the pdf, install and use pdftotext to convert it to a text file, and then read that text file directly with your str_replace_based_edit_tool.
+</IMPORTANT>"""
+
+
+async def sampling_loop(
+    *,
+    model: str,
+    provider: APIProvider,
+    system_prompt_suffix: str,
+    messages: list[BetaMessageParam],
+    output_callback: Callable[[BetaContentBlockParam], None],
+    tool_output_callback: Callable[[ToolResult, str], None],
+    api_response_callback: Callable[
+        [httpx.Request, httpx.Response | object | None, Exception | None], None
+    ],
+    api_key: str,
+    only_n_most_recent_images: int | None = None,
+    max_tokens: int = 4096,
+    tool_version: ToolVersion,
+    thinking_budget: int | None = None,
+    token_efficient_tools_beta: bool = False,
+    tool_collection_override: "ToolCollection | None" = None,
+):
+    """
+    Agentic sampling loop for the assistant/tool interaction of computer use.
+    """
+    tool_group = TOOL_GROUPS_BY_VERSION[tool_version]
+    if tool_collection_override is not None:
+        tool_collection = tool_collection_override
+    else:
+        tool_collection = ToolCollection(*(ToolCls() for ToolCls in tool_group.tools))
+
+    # For SentinelBot runs, use ONLY the sentinel system prompt (no generic VM prompt)
+    if tool_version == "sentinel_playwright" and system_prompt_suffix:
+        system_text = system_prompt_suffix
+    else:
+        system_text = f"{SYSTEM_PROMPT}{' ' + system_prompt_suffix if system_prompt_suffix else ''}"
+
+    system = BetaTextBlockParam(
+        type="text",
+        text=system_text,
+    )
+
+    while True:
+        enable_prompt_caching = False
+        betas = [tool_group.beta_flag] if tool_group.beta_flag else []
+        if token_efficient_tools_beta:
+            betas.append("token-efficient-tools-2025-02-19")
+        image_truncation_threshold = only_n_most_recent_images or 0
+        if provider == APIProvider.ANTHROPIC:
+            client = Anthropic(api_key=api_key, max_retries=4)
+            enable_prompt_caching = True
+        elif provider == APIProvider.VERTEX:
+            client = AnthropicVertex()
+        elif provider == APIProvider.BEDROCK:
+            client = AnthropicBedrock()
+
+        if enable_prompt_caching:
+            betas.append(PROMPT_CACHING_BETA_FLAG)
+            _inject_prompt_caching(messages)
+            # Because cached reads are 10% of the price, we don't think it's
+            # ever sensible to break the cache by truncating images
+            only_n_most_recent_images = 0
+            # Use type ignore to bypass TypedDict check until SDK types are updated
+            system["cache_control"] = {"type": "ephemeral"}  # type: ignore
+
+        if only_n_most_recent_images:
+            _maybe_filter_to_n_most_recent_images(
+                messages,
+                only_n_most_recent_images,
+                min_removal_threshold=image_truncation_threshold,
+            )
+        extra_body = {}
+        if thinking_budget:
+            # Ensure we only send the required fields for thinking
+            extra_body = {
+                "thinking": {"type": "enabled", "budget_tokens": thinking_budget}
+            }
+
+        # Call the API
+        # we use raw_response to provide debug information to streamlit. Your
+        # implementation may be able call the SDK directly with:
+        # `response = client.messages.create(...)` instead.
+        try:
+            raw_response = client.beta.messages.with_raw_response.create(
+                max_tokens=max_tokens,
+                messages=messages,
+                model=model,
+                system=[system],
+                tools=tool_collection.to_params(),
+                betas=betas,
+                extra_body=extra_body,
+            )
+        except (APIStatusError, APIResponseValidationError) as e:
+            api_response_callback(e.request, e.response, e)
+            return messages
+        except APIError as e:
+            api_response_callback(e.request, e.body, e)
+            return messages
+
+        api_response_callback(
+            raw_response.http_response.request, raw_response.http_response, None
+        )
+
+        response = raw_response.parse()
+
+        response_params = _response_to_params(response)
+        messages.append(
+            {
+                "role": "assistant",
+                "content": response_params,
+            }
+        )
+
+        tool_result_content: list[BetaToolResultBlockParam] = []
+        for content_block in response_params:
+            output_callback(content_block)
+            if (
+                isinstance(content_block, dict)
+                and content_block.get("type") == "tool_use"
+            ):
+                # Type narrowing for tool use blocks
+                tool_use_block = cast(BetaToolUseBlockParam, content_block)
+                result = await tool_collection.run(
+                    name=tool_use_block["name"],
+                    tool_input=cast(dict[str, Any], tool_use_block.get("input", {})),
+                )
+                tool_result_content.append(
+                    _make_api_tool_result(result, tool_use_block["id"])
+                )
+                tool_output_callback(result, tool_use_block["id"])
+
+        if not tool_result_content:
+            return messages
+
+        messages.append({"content": tool_result_content, "role": "user"})
+
+
+def _maybe_filter_to_n_most_recent_images(
+    messages: list[BetaMessageParam],
+    images_to_keep: int,
+    min_removal_threshold: int,
+):
+    """
+    With the assumption that images are screenshots that are of diminishing value as
+    the conversation progresses, remove all but the final `images_to_keep` tool_result
+    images in place, with a chunk of min_removal_threshold to reduce the amount we
+    break the implicit prompt cache.
+    """
+    if images_to_keep is None:
+        return messages
+
+    tool_result_blocks = cast(
+        list[BetaToolResultBlockParam],
+        [
+            item
+            for message in messages
+            for item in (
+                message["content"] if isinstance(message["content"], list) else []
+            )
+            if isinstance(item, dict) and item.get("type") == "tool_result"
+        ],
+    )
+
+    total_images = sum(
+        1
+        for tool_result in tool_result_blocks
+        for content in tool_result.get("content", [])
+        if isinstance(content, dict) and content.get("type") == "image"
+    )
+
+    images_to_remove = total_images - images_to_keep
+    # for better cache behavior, we want to remove in chunks
+    images_to_remove -= images_to_remove % min_removal_threshold
+
+    for tool_result in tool_result_blocks:
+        if isinstance(tool_result.get("content"), list):
+            new_content = []
+            for content in tool_result.get("content", []):
+                if isinstance(content, dict) and content.get("type") == "image":
+                    if images_to_remove > 0:
+                        images_to_remove -= 1
+                        continue
+                new_content.append(content)
+            tool_result["content"] = new_content
+
+
+def _response_to_params(
+    response: BetaMessage,
+) -> list[BetaContentBlockParam]:
+    res: list[BetaContentBlockParam] = []
+    for block in response.content:
+        if isinstance(block, BetaTextBlock):
+            if block.text:
+                res.append(BetaTextBlockParam(type="text", text=block.text))
+            elif getattr(block, "type", None) == "thinking":
+                # Handle thinking blocks - include signature field
+                thinking_block = {
+                    "type": "thinking",
+                    "thinking": getattr(block, "thinking", None),
+                }
+                if hasattr(block, "signature"):
+                    thinking_block["signature"] = getattr(block, "signature", None)
+                res.append(cast(BetaContentBlockParam, thinking_block))
+        else:
+            # Handle tool use blocks normally
+            res.append(cast(BetaToolUseBlockParam, block.model_dump()))
+    return res
+
+
+def _inject_prompt_caching(
+    messages: list[BetaMessageParam],
+):
+    """
+    Set cache breakpoints for the 3 most recent turns
+    one cache breakpoint is left for tools/system prompt, to be shared across sessions
+    """
+
+    breakpoints_remaining = 3
+    for message in reversed(messages):
+        if message["role"] == "user" and isinstance(
+            content := message["content"], list
+        ):
+            if breakpoints_remaining:
+                breakpoints_remaining -= 1
+                # Use type ignore to bypass TypedDict check until SDK types are updated
+                content[-1]["cache_control"] = BetaCacheControlEphemeralParam(  # type: ignore
+                    {"type": "ephemeral"}
+                )
+            else:
+                if isinstance(content[-1], dict) and "cache_control" in content[-1]:
+                    del content[-1]["cache_control"]  # type: ignore
+                # we'll only every have one extra turn per loop
+                break
+
+
+def _make_api_tool_result(
+    result: ToolResult, tool_use_id: str
+) -> BetaToolResultBlockParam:
+    """Convert an agent ToolResult to an API ToolResultBlockParam."""
+    tool_result_content: list[BetaTextBlockParam | BetaImageBlockParam] | str = []
+    is_error = False
+    if result.error:
+        is_error = True
+        tool_result_content = _maybe_prepend_system_tool_result(result, result.error)
+    else:
+        if result.output:
+            tool_result_content.append(
+                {
+                    "type": "text",
+                    "text": _maybe_prepend_system_tool_result(result, result.output),
+                }
+            )
+        if result.base64_image:
+            tool_result_content.append(
+                {
+                    "type": "image",
+                    "source": {
+                        "type": "base64",
+                        "media_type": "image/png",
+                        "data": result.base64_image,
+                    },
+                }
+            )
+    return {
+        "type": "tool_result",
+        "content": tool_result_content,
+        "tool_use_id": tool_use_id,
+        "is_error": is_error,
+    }
+
+
+def _maybe_prepend_system_tool_result(result: ToolResult, result_text: str):
+    if result.system:
+        result_text = f"<system>{result.system}</system>\n{result_text}"
+    return result_text

--- a/sentinelbot/sentinel/requirements-sentinel.txt
+++ b/sentinelbot/sentinel/requirements-sentinel.txt
@@ -1,0 +1,7 @@
+anthropic>=0.39.0
+playwright>=1.40.0
+Pillow>=10.0.0
+fastapi>=0.104.0
+uvicorn[standard]>=0.24.0
+httpx>=0.25.0
+supabase>=2.0.0

--- a/sentinelbot/sentinel/scheduler.py
+++ b/sentinelbot/sentinel/scheduler.py
@@ -1,0 +1,201 @@
+from __future__ import annotations
+
+import asyncio
+import itertools
+import logging
+import uuid
+from datetime import datetime, timezone
+from typing import Any
+
+from pydantic import BaseModel
+
+logger = logging.getLogger(__name__)
+
+
+class ScheduleConfig(BaseModel):
+    """Configuration for a continuous monitoring schedule."""
+
+    project_id: str
+    device_ids: list[str]
+    network_ids: list[str]
+    locales: list[str] = ["en-US"]
+    personas: list[str | None] = [None]
+    interval_minutes: int = 60
+    model: str = "claude-sonnet-4-5-20250929"
+    max_tokens: int = 8192
+    thinking_budget: int | None = None
+    only_n_most_recent_images: int = 3
+    task: str | None = None
+    input_data: dict[str, str | int] | None = None
+    sensitive_keys: list[str] | None = None
+    enabled: bool = True
+
+
+class ScheduleState(BaseModel):
+    """Runtime state for an active schedule."""
+
+    schedule_id: str
+    config: ScheduleConfig
+    created_at: str
+    is_running: bool = False
+    current_run_id: str | None = None
+    total_runs: int = 0
+    last_run_at: str | None = None
+    next_combo_index: int = 0
+
+
+class ContinuousScheduler:
+    """Manages rotating test schedules across device/network/locale combos.
+
+    Each schedule rotates through all combinations of (device, network, locale, persona)
+    on a timed interval.
+    """
+
+    def __init__(self):
+        self._schedules: dict[str, ScheduleState] = {}
+        self._tasks: dict[str, asyncio.Task] = {}
+
+    @property
+    def schedules(self) -> dict[str, ScheduleState]:
+        return self._schedules
+
+    def create_schedule(self, config: ScheduleConfig) -> ScheduleState:
+        """Register a new schedule (does not start it)."""
+        schedule_id = str(uuid.uuid4())
+        state = ScheduleState(
+            schedule_id=schedule_id,
+            config=config,
+            created_at=datetime.now(timezone.utc).isoformat(),
+        )
+        self._schedules[schedule_id] = state
+        logger.info(
+            f"Schedule {schedule_id} created for project {config.project_id} "
+            f"({len(self._get_combos(config))} combos, every {config.interval_minutes}m)"
+        )
+        return state
+
+    def start_schedule(self, schedule_id: str, run_test_fn) -> None:
+        """Start the asyncio loop for a schedule.
+
+        Args:
+            schedule_id: ID returned by create_schedule
+            run_test_fn: Async callable(project_id, device_id, network_id, locale, persona, model, ...)
+                         that triggers a single test run. This is wired to the server's _execute_run.
+        """
+        if schedule_id not in self._schedules:
+            raise ValueError(f"Schedule {schedule_id} not found")
+        if schedule_id in self._tasks:
+            raise ValueError(f"Schedule {schedule_id} is already running")
+
+        state = self._schedules[schedule_id]
+        task = asyncio.create_task(
+            self._run_loop(state, run_test_fn),
+            name=f"schedule-{schedule_id}",
+        )
+        self._tasks[schedule_id] = task
+        logger.info(f"Schedule {schedule_id} started")
+
+    def stop_schedule(self, schedule_id: str) -> None:
+        """Cancel the asyncio task for a schedule."""
+        task = self._tasks.pop(schedule_id, None)
+        if task:
+            task.cancel()
+            logger.info(f"Schedule {schedule_id} stopped")
+        state = self._schedules.get(schedule_id)
+        if state:
+            state.is_running = False
+
+    def delete_schedule(self, schedule_id: str) -> None:
+        """Stop and remove a schedule."""
+        self.stop_schedule(schedule_id)
+        self._schedules.pop(schedule_id, None)
+
+    def get_schedule(self, schedule_id: str) -> ScheduleState | None:
+        return self._schedules.get(schedule_id)
+
+    def list_schedules(self) -> list[ScheduleState]:
+        return list(self._schedules.values())
+
+    # ── Internal ────────────────────────────────────────────────────
+
+    @staticmethod
+    def _get_combos(config: ScheduleConfig) -> list[dict[str, Any]]:
+        """Generate all (device, network, locale, persona) combinations."""
+        combos = []
+        for device_id, network_id, locale, persona in itertools.product(
+            config.device_ids,
+            config.network_ids,
+            config.locales,
+            config.personas,
+        ):
+            combos.append({
+                "device_id": device_id,
+                "network_id": network_id,
+                "locale": locale,
+                "persona": persona,
+            })
+        return combos
+
+    async def _run_loop(self, state: ScheduleState, run_test_fn) -> None:
+        """Infinite loop: run one combo, sleep, repeat."""
+        config = state.config
+        combos = self._get_combos(config)
+
+        if not combos:
+            logger.warning(f"Schedule {state.schedule_id}: no combos to run")
+            return
+
+        state.is_running = True
+        logger.info(
+            f"Schedule {state.schedule_id}: entering loop with {len(combos)} combos, "
+            f"interval={config.interval_minutes}m"
+        )
+
+        try:
+            while True:
+                combo = combos[state.next_combo_index % len(combos)]
+                state.next_combo_index = (state.next_combo_index + 1) % len(combos)
+
+                logger.info(
+                    f"Schedule {state.schedule_id}: running combo "
+                    f"device={combo['device_id'][:8]}… network={combo['network_id'][:8]}… "
+                    f"locale={combo['locale']} persona={combo['persona']}"
+                )
+
+                try:
+                    run_id = await run_test_fn(
+                        project_id=config.project_id,
+                        device_id=combo["device_id"],
+                        network_id=combo["network_id"],
+                        locale=combo["locale"],
+                        persona=combo["persona"],
+                        model=config.model,
+                        max_tokens=config.max_tokens,
+                        thinking_budget=config.thinking_budget,
+                        only_n_most_recent_images=config.only_n_most_recent_images,
+                        task=config.task,
+                        input_data=config.input_data,
+                        sensitive_keys=config.sensitive_keys,
+                    )
+                    state.current_run_id = run_id
+                    state.total_runs += 1
+                    state.last_run_at = datetime.now(timezone.utc).isoformat()
+                    logger.info(
+                        f"Schedule {state.schedule_id}: run {run_id} started "
+                        f"(total: {state.total_runs})"
+                    )
+                except Exception as e:
+                    logger.error(
+                        f"Schedule {state.schedule_id}: failed to start run: {e}",
+                        exc_info=True,
+                    )
+
+                # Sleep until next interval
+                await asyncio.sleep(config.interval_minutes * 60)
+
+        except asyncio.CancelledError:
+            logger.info(f"Schedule {state.schedule_id}: cancelled")
+            state.is_running = False
+        except Exception as e:
+            logger.error(f"Schedule {state.schedule_id}: loop crashed: {e}", exc_info=True)
+            state.is_running = False

--- a/sentinelbot/sentinel/sentinel_capture.py
+++ b/sentinelbot/sentinel/sentinel_capture.py
@@ -1,0 +1,79 @@
+import base64
+import json
+import os
+from datetime import datetime, timezone
+
+
+def make_run_dir(base_dir: str = "/tmp/sentinel_runs") -> tuple[str, str]:
+    """Create a timestamped run directory.
+
+    Returns:
+        Tuple of (run_id, run_dir_path)
+    """
+    ts = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H-%M-%S-%f")[:-3] + "Z"
+    run_id = f"run_{ts}"
+    run_dir = os.path.join(base_dir, run_id)
+    os.makedirs(run_dir, exist_ok=True)
+    return run_id, run_dir
+
+
+def make_run_paths(run_dir: str) -> dict[str, str]:
+    """Create subdirectories for screenshots, logs, and videos.
+
+    Matches sentinel-manual-agent's directory structure:
+        run_<timestamp>/
+            screenshots/
+            logs/
+            videos/
+    """
+    paths = {
+        "screenshots": os.path.join(run_dir, "screenshots"),
+        "logs": os.path.join(run_dir, "logs"),
+        "videos": os.path.join(run_dir, "videos"),
+    }
+    for p in paths.values():
+        os.makedirs(p, exist_ok=True)
+    return paths
+
+
+def append_log(log_file: str, entry: dict):
+    """Append a JSONL entry to the log file.
+
+    Each entry is a single JSON object on its own line,
+    matching sentinel-manual-agent's events.jsonl format.
+    """
+    with open(log_file, "a") as f:
+        f.write(json.dumps(entry, default=str) + "\n")
+
+
+def save_screenshot(screenshots_dir: str, step: int, base64_image: str) -> str:
+    """Save a base64-encoded PNG screenshot to disk.
+
+    Args:
+        screenshots_dir: Directory to save the screenshot
+        step: Step number (used for filename ordering)
+        base64_image: Base64-encoded PNG data
+
+    Returns:
+        The filename (not full path) of the saved screenshot
+    """
+    filename = f"step_{step:03d}.png"
+    filepath = os.path.join(screenshots_dir, filename)
+    with open(filepath, "wb") as f:
+        f.write(base64.b64decode(base64_image))
+    return filename
+
+
+def read_events_log(log_file: str) -> list[dict]:
+    """Read all events from a JSONL log file."""
+    events = []
+    if os.path.exists(log_file):
+        with open(log_file, "r") as f:
+            for line in f:
+                line = line.strip()
+                if line:
+                    try:
+                        events.append(json.loads(line))
+                    except json.JSONDecodeError:
+                        pass
+    return events

--- a/sentinelbot/sentinel/sentinel_prompt.py
+++ b/sentinelbot/sentinel/sentinel_prompt.py
@@ -1,0 +1,410 @@
+from datetime import datetime
+
+
+# ── Persona Definitions ─────────────────────────────────────────────────
+
+PERSONA_PROFILES: dict[str, dict[str, str]] = {
+    "first_time_user": {
+        "label": "First-Time User",
+        "behavior": (
+            "You are a FIRST-TIME user who has never used this app before. "
+            "You are unfamiliar with the layout and features. You read every label, "
+            "look for obvious affordances (buttons, links), and may try incorrect paths "
+            "before finding the right one. You are easily confused by jargon, unclear "
+            "icons, or non-standard UI patterns. If something is not obvious within 5 seconds, "
+            "flag it as a UX issue. You type slowly and sometimes make typos."
+        ),
+    },
+    "power_user": {
+        "label": "Power User",
+        "behavior": (
+            "You are a POWER USER who uses apps like this daily. You expect keyboard "
+            "shortcuts, fast navigation, and efficient workflows. You try to skip steps, "
+            "use browser back/forward aggressively, open links in new tabs, and find the "
+            "fastest path through any flow. You are frustrated by unnecessary confirmation "
+            "dialogs, forced delays, or redundant steps. Flag any workflow inefficiencies."
+        ),
+    },
+    "elderly_user": {
+        "label": "Elderly / Low Vision User",
+        "behavior": (
+            "You are an ELDERLY user with reduced vision. You rely on large text, high "
+            "contrast, and clear labels. Tiny touch targets frustrate you. You double-tap "
+            "things accidentally, scroll slowly, and may not notice small UI changes. "
+            "Flag any text smaller than ~14px, low-contrast elements, touch targets under "
+            "44x44px, or confusing navigation as accessibility issues."
+        ),
+    },
+    "non_technical_user": {
+        "label": "Non-Technical User",
+        "behavior": (
+            "You are a NON-TECHNICAL user who is intimidated by technology. You expect "
+            "everything to be self-explanatory. Error messages with technical jargon "
+            "confuse you. You don't understand what 'HTTP 500' means — you just know it's "
+            "broken. You might try clicking non-interactive elements, confuse icons for "
+            "buttons, or miss subtle UI cues. Flag any confusing error messages, unclear "
+            "labels, or unintuitive interactions."
+        ),
+    },
+    "impatient_user": {
+        "label": "Impatient / Rushing User",
+        "behavior": (
+            "You are an IMPATIENT user in a hurry. You click buttons before pages finish "
+            "loading, rapidly scroll past content, skip reading instructions, submit forms "
+            "with partial data, and double-click everything. You expect instant feedback. "
+            "If a loading spinner shows for more than 2 seconds, you try clicking again. "
+            "Flag race conditions, missing loading states, double-submit issues, and slow responses."
+        ),
+    },
+    "adversarial_user": {
+        "label": "Adversarial / Edge-Case Tester",
+        "behavior": (
+            "You are an ADVERSARIAL user trying to break things. You enter SQL injection "
+            "strings, XSS payloads, extremely long text, special characters (emoji, RTL text, "
+            "zero-width spaces), and boundary values (0, -1, 999999). You try to access "
+            "pages out of order, manipulate URL parameters, and exploit any input field. "
+            "Flag any input that causes errors, layout breakage, or unexpected behavior."
+        ),
+    },
+}
+
+
+def get_sentinel_system_prompt(
+    *,
+    device_label: str = "mobile device",
+    network_label: str = "WiFi",
+    target_url: str = "",
+    persona: str | None = None,
+    locale: str = "en-US",
+) -> str:
+    """Generate the SentinelBot QA system prompt with run-specific context.
+
+    Args:
+        device_label: Human-readable device name for context
+        network_label: Human-readable network condition name
+        target_url: The URL being tested
+        persona: Optional persona key (e.g. "first_time_user", "power_user")
+        locale: Browser locale code (e.g. "en-US", "fr-FR", "ar-SA")
+    """
+    # ── Persona section ─────────────────────────────────────────────
+    persona_section = ""
+    if persona and persona in PERSONA_PROFILES:
+        p = PERSONA_PROFILES[persona]
+        persona_section = f"""
+<PERSONA>
+You are testing as: **{p['label']}**
+{p['behavior']}
+Incorporate this persona into your testing approach. Your issue reports should reflect
+what THIS type of user would experience and struggle with.
+</PERSONA>
+"""
+
+    # ── Locale / multi-language section ─────────────────────────────
+    locale_section = ""
+    if locale and locale != "en-US":
+        lang_name = _locale_to_language_name(locale)
+        locale_section = f"""
+<MULTI_LANGUAGE_TESTING>
+The browser locale is set to **{locale}** ({lang_name}).
+You MUST check for these localisation issues:
+* **Untranslated strings**: Any English text that should be in {lang_name}. Flag as P2.
+* **Truncated translations**: Text cut off because the translation is longer than English. Flag as P2.
+* **Layout breakage**: UI elements overlapping or misaligned due to text length differences. Flag as P1.
+* **Date/number format**: Dates, currencies, and numbers should match {locale} conventions.
+* **RTL issues** (if applicable): For Arabic, Hebrew, Urdu, Farsi — check that layout is mirrored correctly.
+* **Character encoding**: Garbled or missing characters (mojibake). Flag as P1.
+* **Placeholder text**: Form placeholders still in English or showing raw i18n keys like "{{{{key}}}}". Flag as P2.
+Report any localisation issues with category "visual" and include the untranslated/broken text in the description.
+</MULTI_LANGUAGE_TESTING>
+"""
+
+    return f"""<SYSTEM_CAPABILITY>
+* You are SentinelBot, an expert mobile QA tester using a Playwright-controlled browser.
+* You are viewing a mobile browser emulating a {device_label}.
+* Network condition: {network_label}.
+* The browser viewport matches the device dimensions exactly — coordinates you see are the coordinates you click.
+* You can interact with the page using the computer tool actions listed below.
+* The current date is {datetime.today().strftime("%A, %B %-d, %Y")}.
+</SYSTEM_CAPABILITY>
+{persona_section}{locale_section}
+
+<ACCESSIBILITY_AUDITING>
+After your testing session, an automated WCAG 2.1 AA accessibility audit (axe-core) will run
+on every page you visit. The audit results will be converted to issues automatically.
+However, YOU should also look for accessibility problems that automated tools miss:
+* **Logical tab order**: Does the focus order make sense when pressing Tab?
+* **Meaningful alt text**: Are images described usefully, not just "image" or "photo"?
+* **Touch target size**: Mobile tap targets should be at least 44x44px.
+* **Color-only indicators**: Information conveyed only by color (no icon/text backup).
+* **Dynamic content**: Do modals, drawers, and popups trap focus correctly?
+* **Error identification**: Are form errors described in text, not just red borders?
+Report any accessibility issues you observe visually with category "accessibility".
+The automated axe-core audit will supplement your observations with WCAG-specific violations.
+</ACCESSIBILITY_AUDITING>
+<TOOL_USAGE_RULES>
+You control a Playwright browser. Follow these rules EXACTLY to avoid errors.
+
+ACTIONS AND PARAMETERS:
+* left_click(coordinate=[x,y]) — tap at coordinates. Coordinate is REQUIRED.
+* right_click(coordinate=[x,y]) — right-click at coordinates.
+* double_click(coordinate=[x,y]) — double-click at coordinates.
+* triple_click(coordinate=[x,y]) — triple-click (select all text in field).
+* type(text="...") — type text into the currently focused element. Do NOT pass coordinate.
+* key(text="...") — press a SINGLE key per call. Do NOT pass coordinate. See valid key names below.
+* scroll(coordinate=[x,y], scroll_direction="down", scroll_amount=3) — scroll at position.
+* mouse_move(coordinate=[x,y]) — move cursor without clicking.
+* screenshot() — capture current page state. Use frequently.
+* wait(duration=2) — wait N seconds (max 100).
+* left_click_drag(start_coordinate=[x,y], coordinate=[x,y]) — drag from start to end.
+
+VALID KEY NAMES (use these exactly):
+* Text keys: Enter, Tab, Backspace, Delete, Escape, Space
+* Arrow keys: ArrowUp, ArrowDown, ArrowLeft, ArrowRight
+* Navigation: Home, End, PageUp, PageDown
+* Modifiers: Shift, Control, Alt, Meta
+* Function keys: F1, F2, ... F12
+* Combinations: Use "+" to combine, e.g. "Control+a", "Shift+Tab", "Meta+c"
+* Single characters: "a", "b", "1", etc.
+
+KEY ACTION RULES:
+* ONLY pass ONE key name per key() call. NEVER repeat or space-separate keys.
+  - WRONG: key(text="Backspace Backspace Backspace")
+  - RIGHT: Call key(text="Backspace") three separate times.
+* To delete multiple characters, prefer: triple_click to select all, then key(text="Backspace") once.
+* To clear a text field: triple_click(coordinate=[x,y]) then key(text="Backspace").
+* Do NOT invent key names. Only use the names listed above.
+
+INVALID KEY NAMES — DO NOT USE THESE:
+* "cmd" — use "Meta" instead
+* "command" — use "Meta" instead
+* "ctrl" — use "Control" instead
+* "return" — use "Enter" instead
+* "esc" — use "Escape" instead
+* "space" — use "Space" instead (or just type " ")
+
+COMMON PATTERNS:
+* To fill a text field: left_click on the field, then use action="type" with text="your text".
+* To clear a field: action="triple_click" to select all, then action="key" with text="Backspace".
+* To delete multiple characters: Do NOT send "Backspace Backspace Backspace". Instead, use action="triple_click" then action="key" with text="Backspace" once.
+* To submit a form: action="key" with text="Enter", or left_click the submit button.
+* To go back: click the browser's back button or a visible back/close element on the page.
+* To select all text: action="key" with text="Control+a".
+* To scroll down: action="scroll" with coordinate=[x,y], scroll_direction="down", scroll_amount=3.
+* To press a key combo: action="key" with text="Control+c" (use + to combine keys).
+
+COORDINATE RULES:
+* Always provide coordinate as [x, y] for click/scroll actions.
+* Coordinates must be within the viewport: x in [0, {device_label.split('(')[1].split('x')[0] if '(' in device_label else '390'}), y in [0, {device_label.split('x')[1].rstrip(')') if '(' in device_label else '844'}).
+* Do NOT pass coordinate for type or key actions.
+* Look at the screenshot carefully to identify the right coordinates for interactive elements.
+</TOOL_USAGE_RULES>
+
+<TESTING_GUIDELINES>
+* Navigate to the given URL and systematically test the main user flow.
+* Test like a real user: try filling forms, clicking buttons, navigating between pages.
+* Pay attention to:
+  - Form validation (empty fields, invalid inputs, edge cases)
+  - Button states (disabled, loading, error states)
+  - Navigation flow (back button, redirects, deep links)
+  - Visual regressions (overlapping elements, cut-off text, misaligned layouts)
+  - Error handling (network errors, server errors, timeout behaviors)
+  - Accessibility (font sizes, contrast, touch target sizes on mobile)
+  - Mobile-specific issues (viewport overflow, horizontal scrolling, keyboard behavior)
+  - Loading states and performance (spinners, skeleton screens, responsiveness)
+  - Touch interactions (tap targets too small, swipe behavior)
+* After each significant action, take a screenshot to verify the result.
+* If you encounter a bug or issue, document it clearly with:
+  - What you did (steps to reproduce)
+  - What you expected
+  - What actually happened
+  - The screenshot as evidence
+* Test both happy paths and edge cases.
+* When done, provide a structured summary of all findings.
+</TESTING_GUIDELINES>
+
+<CAPTCHA_AND_OTP_HANDLING>
+If you encounter a CAPTCHA, OTP (one-time password), SMS verification, email verification,
+two-factor authentication, or any human-verification gate:
+1. **Do NOT get stuck** trying to solve it. Spend at most 1 action attempting it.
+2. **Take a screenshot** of the CAPTCHA/OTP screen as evidence.
+3. **Log it** in your output with:
+   - `captcha_encountered: true`
+   - The type of gate (CAPTCHA, OTP, email verification, etc.)
+   - The exact step where you encountered it
+4. **Skip past it** if possible (try "skip", "later", or an alternative path).
+5. **Continue testing** other parts of the application that don't require authentication.
+6. Report it as an issue ONLY if:
+   - The CAPTCHA blocks ALL functionality (P1)
+   - There's no "skip" or "guest" option for public features (P2)
+   - The CAPTCHA is broken or unloadable (P1)
+</CAPTCHA_AND_OTP_HANDLING>
+
+<UX_CONFUSION_DETECTION>
+You MUST track your own confusion and hesitation as a signal of UX problems:
+* **Page dwell time**: If you spend more than 3 actions on a single screen looking for
+  what to do next, this is a UX confusion signal. Log it.
+* **Backtracking**: If you navigate backward because you went the wrong way, this
+  indicates unclear navigation. Log it.
+* **Repeated clicks**: If you click the same area multiple times because nothing seems
+  to happen, log it as poor feedback.
+* **Label confusion**: If you can't tell what a button/link does from its label, log it.
+* **Hidden elements**: If you have to scroll extensively to find a primary action (like
+  "Submit" or "Next"), this is a UX issue.
+* **Dead ends**: If a flow leads nowhere with no clear next step, this is critical UX failure.
+
+For each confusion event, record:
+- The screen/page where it happened
+- What you were trying to do
+- Why it was confusing
+- How many extra actions it took
+- The step number for screenshot evidence
+</UX_CONFUSION_DETECTION>
+
+<SMART_SEVERITY_SCORING>
+Use these STRICT criteria for severity classification:
+
+**P0 — Showstopper (app is unusable)**
+* Application crash or white screen of death
+* Data loss (submitted form data disappears)
+* Security vulnerability (exposed PII, open redirects, XSS that executes)
+* Payment/checkout completely broken
+* Login/signup entirely non-functional
+
+**P1 — Critical (major feature broken)**
+* Core user flow blocked (cannot complete the primary task)
+* Submit/Save button doesn't work
+* Forms accept invalid data that corrupts state (e.g., submitting empty required fields succeeds)
+* Broken navigation — user gets trapped with no way back
+* Page fails to load on the tested network condition
+* Severe layout breakage making content unreadable
+* CAPTCHA/OTP blocking all access with no alternative
+
+**P2 — Major (feature works but has significant problems)**
+* Non-critical feature broken (search, filters, secondary actions)
+* Form validation missing but form still submits
+* Slow performance (>3s load time on current network)
+* Accessibility issues (contrast, font size, touch targets)
+* Localisation/translation errors
+* Inconsistent UI states (loading spinners stuck, stale data)
+
+**P3 — Minor (cosmetic or low-impact)**
+* Typos, grammar errors in static text
+* Minor visual misalignment (< 5px off)
+* Favicon missing
+* Console warnings (not errors)
+* Placeholder text still visible in non-critical areas
+* Tooltip or hover state quirks
+
+Always include a `severity_justification` explaining WHY you chose that level.
+</SMART_SEVERITY_SCORING>
+
+<OUTPUT_FORMAT>
+When you complete testing, output your findings as a SINGLE JSON code block (```json ... ```).
+Do NOT add any text before or after the JSON block.
+
+Use this exact schema:
+```json
+{{
+  "summary": "Brief 1-2 sentence overview of what was tested and the overall result",
+  "url": "{target_url or '[url]'}",
+  "device": "{device_label}",
+  "network": "{network_label}",
+  "tests_passed": ["Login flow works", "Navigation is smooth"],
+  "captcha_encountered": false,
+  "captcha_details": null,
+  "issues": [
+    {{
+      "id": "ISSUE-1",
+      "severity": "P1",
+      "severity_justification": "Submit button completely non-functional, blocking the core checkout flow",
+      "title": "Short descriptive title",
+      "description": "Detailed description of the issue",
+      "steps_to_reproduce": ["Step 1", "Step 2", "Step 3"],
+      "expected": "What should happen",
+      "actual": "What actually happens",
+      "screenshot_step": 5,
+      "category": "functional|visual|performance|accessibility|mobile"
+    }}
+  ],
+  "ux_confusion_events": [
+    {{
+      "screen": "Checkout page",
+      "intent": "Find the submit button",
+      "confusion_reason": "Submit button is below the fold and requires scrolling past terms",
+      "extra_actions_needed": 3,
+      "screenshot_step": 12
+    }}
+  ],
+  "locale_issues": [
+    {{
+      "text_found": "Submit Order",
+      "expected_language": "French",
+      "location": "Checkout button",
+      "type": "untranslated_string",
+      "screenshot_step": 8
+    }}
+  ],
+  "recommendations": ["Suggestion 1", "Suggestion 2"]
+}}
+```
+
+RULES:
+* severity: P0 = showstopper, P1 = critical/blocker, P2 = major, P3 = minor/cosmetic.
+* severity_justification: REQUIRED — explain why this level was chosen using the criteria above.
+* screenshot_step: the step number whose screenshot best shows the issue (from your action sequence).
+* category: one of functional, visual, performance, accessibility, mobile.
+* If no issues found, set "issues" to an empty array [].
+* If no UX confusion events, set "ux_confusion_events" to an empty array [].
+* If no locale issues, set "locale_issues" to an empty array [].
+* captcha_encountered: true if you hit any CAPTCHA/OTP/verification gate.
+* captcha_details: if encountered, describe the type and what step it appeared at. Otherwise null.
+* tests_passed: list features/flows that worked correctly.
+</OUTPUT_FORMAT>
+
+<REALTIME_ISSUE_REPORTING>
+IMPORTANT: Report issues AS SOON AS you discover them — do NOT wait until the end.
+
+Whenever you find a bug or issue during testing, IMMEDIATELY output a line in this exact format:
+
+🚨 ISSUE_FOUND: {{"severity": "P1", "title": "Short title", "description": "Detailed description", "steps_to_reproduce": ["Step 1", "Step 2"], "expected": "What should happen", "actual": "What happens", "screenshot_step": 5, "category": "functional", "severity_justification": "Why this severity"}}
+
+Rules for real-time reporting:
+* Output ONE 🚨 ISSUE_FOUND line per issue, immediately after you observe it.
+* The JSON must be on a SINGLE LINE after "🚨 ISSUE_FOUND: ".
+* Use the screenshot_step number of the MOST RECENT action (the one that revealed the issue).
+* Continue testing after reporting — do NOT stop.
+* At the end, still output the full JSON summary as described in OUTPUT_FORMAT.
+  The final summary should include ALL issues (both previously reported and any new ones).
+* This enables real-time alerting — issues get escalated to the team the moment they're found.
+</REALTIME_ISSUE_REPORTING>
+
+<IMPORTANT>
+* SCREENSHOTS ARE AUTOMATIC: Every action (click, type, key, scroll, wait) automatically returns a screenshot. You do NOT need to call screenshot() after actions — you will already see the result. Only use screenshot() when you want to observe the page WITHOUT performing any action (e.g. checking if a page has finished loading).
+* If a page is loading, use wait(duration=2) — the wait action returns a screenshot automatically.
+* If you see a cookie banner or popup, dismiss it first before testing.
+* Test with realistic data — use plausible names, emails, phone numbers.
+* Do NOT skip testing because something "looks fine" — verify by interacting with it.
+* If the page doesn't load or times out, report it as a Critical issue.
+* If a key action fails, check the VALID KEY NAMES list and correct the key name.
+</IMPORTANT>"""
+
+
+def _locale_to_language_name(locale: str) -> str:
+    """Map a locale code to a human-readable language name."""
+    LOCALE_MAP = {
+        "af": "Afrikaans", "ar": "Arabic", "bg": "Bulgarian", "bn": "Bengali",
+        "ca": "Catalan", "cs": "Czech", "da": "Danish", "de": "German",
+        "el": "Greek", "en": "English", "es": "Spanish", "et": "Estonian",
+        "fa": "Farsi", "fi": "Finnish", "fr": "French", "gu": "Gujarati",
+        "he": "Hebrew", "hi": "Hindi", "hr": "Croatian", "hu": "Hungarian",
+        "id": "Indonesian", "it": "Italian", "ja": "Japanese", "kn": "Kannada",
+        "ko": "Korean", "lt": "Lithuanian", "lv": "Latvian", "ml": "Malayalam",
+        "mr": "Marathi", "ms": "Malay", "nb": "Norwegian", "nl": "Dutch",
+        "pl": "Polish", "pt": "Portuguese", "ro": "Romanian", "ru": "Russian",
+        "sk": "Slovak", "sl": "Slovenian", "sr": "Serbian", "sv": "Swedish",
+        "sw": "Swahili", "ta": "Tamil", "te": "Telugu", "th": "Thai",
+        "tr": "Turkish", "uk": "Ukrainian", "ur": "Urdu", "vi": "Vietnamese",
+        "zh": "Chinese",
+    }
+    lang_code = locale.split("-")[0].lower()
+    return LOCALE_MAP.get(lang_code, locale)

--- a/sentinelbot/sentinel/sentinel_server.py
+++ b/sentinelbot/sentinel/sentinel_server.py
@@ -1,0 +1,2335 @@
+import asyncio
+import glob
+import json
+import logging
+import os
+import re
+import time
+import traceback
+from collections import deque
+from typing import Any
+
+import httpx
+from fastapi import BackgroundTasks, FastAPI, HTTPException
+from fastapi.middleware.cors import CORSMiddleware
+from pydantic import BaseModel
+
+from sentinel.loop import APIProvider, sampling_loop
+from sentinel.sentinel_prompt import get_sentinel_system_prompt, PERSONA_PROFILES
+from sentinel.tools import PlaywrightComputerTool, ToolCollection
+from sentinel.tools.base import ToolResult
+from sentinel.tools.bash import BashTool20250124
+from sentinel.scheduler import ContinuousScheduler, ScheduleConfig
+from sentinel.slack_notifier import (
+    _get_owner_for_category,
+    find_or_create_channel,
+    is_slack_configured,
+    post_issue_to_slack,
+    post_run_summary_to_slack,
+)
+
+# DB layer
+from sentinel.db.db_devices import (
+    device_to_playwright_profile,
+    get_device_by_id,
+    get_network_by_id,
+    list_devices,
+    list_networks,
+    network_to_throttle_profile,
+)
+from sentinel.db.db_evidence import (
+    ensure_buckets_exist,
+    get_evidence_for_run,
+    link_evidence_to_issue,
+    upload_screenshot,
+    upload_video,
+)
+from sentinel.db.db_issues import (
+    _jaccard_similarity,
+    _tokenize,
+    create_issue,
+    find_similar_issues,
+    get_issue_frequency,
+    get_issues_for_run,
+    link_issue_to_run,
+)
+from sentinel.db.db_logs import insert_log, insert_step
+from sentinel.db.db_runs import (
+    create_run,
+    get_previous_run,
+    get_run as db_get_run,
+    list_runs as db_list_runs,
+    update_run_completed,
+    update_run_failed,
+)
+from sentinel.db.db_perf import (
+    insert_perf_metrics,
+    get_perf_metrics_for_run,
+)
+
+# ── Logging ─────────────────────────────────────────────────────────────
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s | %(levelname)s | %(name)s | %(message)s",
+)
+logger = logging.getLogger(__name__)
+
+# ── FastAPI app ─────────────────────────────────────────────────────────
+
+app = FastAPI(
+    title="SentinelBot",
+    description="Claude-powered mobile QA testing via Playwright, persisted to Supabase",
+    version="0.3.0",
+)
+
+# ── Continuous Monitoring Scheduler ─────────────────────────────────────
+scheduler = ContinuousScheduler()
+
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+
+# Temp dir for video recording (uploaded to Supabase after run)
+VIDEO_TMP_DIR = os.environ.get("SENTINEL_VIDEO_DIR", "/tmp/sentinel_videos")
+
+# ── Sensitive key auto-detection ────────────────────────────────────────
+# Patterns (lowercased, substring match) that mark a key as sensitive.
+_SENSITIVE_PATTERNS: list[str] = [
+    "password", "passwd", "pass_word",
+    "secret", "token", "api_key", "apikey",
+    "otp", "pin", "mpin",
+    "ssn", "social_security",
+    "credit_card", "creditcard", "card_number", "cardnumber",
+    "cvv", "cvc", "ccv",
+    "mobile", "phone", "cell",
+    "auth", "credential",
+    "private_key", "privatekey",
+    "access_key", "accesskey",
+]
+
+
+def _detect_sensitive_keys(
+    input_data: dict[str, str],
+    extra_sensitive_keys: list[str] | None = None,
+) -> set[str]:
+    """Return the set of keys in *input_data* that should be masked in logs.
+
+    Auto-detects common sensitive patterns (password, phone, token, …)
+    and merges with any explicitly provided *extra_sensitive_keys*.
+    """
+    detected: set[str] = set()
+    for key in input_data:
+        key_lower = key.lower().replace("-", "_").replace(" ", "_")
+        if any(pat in key_lower for pat in _SENSITIVE_PATTERNS):
+            detected.add(key)
+    if extra_sensitive_keys:
+        detected.update(extra_sensitive_keys)
+    return detected
+
+
+def _mask_input_data(
+    input_data: dict[str, str],
+    extra_sensitive_keys: list[str] | None = None,
+) -> dict[str, str]:
+    """Return a copy of *input_data* with sensitive values replaced by '****'."""
+    sensitive = _detect_sensitive_keys(input_data, extra_sensitive_keys)
+    return {
+        k: ("****" if k in sensitive else v)
+        for k, v in input_data.items()
+    }
+
+
+@app.on_event("startup")
+async def _startup():
+    """Ensure Supabase storage buckets exist on server start."""
+    try:
+        ensure_buckets_exist()
+        logger.info("Supabase storage buckets verified")
+    except Exception as e:
+        logger.warning(f"Could not verify storage buckets: {e}")
+
+
+# ── Request / Response Models ───────────────────────────────────────────
+
+
+class TestRequest(BaseModel):
+    """Configuration for a QA test run."""
+
+    project_id: str
+    device_id: str
+    network_id: str
+    task: str | None = None
+    model: str = "claude-sonnet-4-5-20250929"
+    locale: str = "en-US"
+    persona: str | None = None
+    max_tokens: int = 8192
+    thinking_budget: int | None = None
+    only_n_most_recent_images: int = 3
+
+    # ── User-provided test inputs ──────────────────────────────────
+    # Arbitrary key-value pairs for the agent to use during testing
+    # (e.g. login credentials, form data, search queries).
+    input_data: dict[str, str] | None = None
+    # Extra keys to mask in logs on top of auto-detected ones.
+    # Auto-detection covers: password, token, otp, phone/mobile, ssn, etc.
+    sensitive_keys: list[str] | None = None
+
+    # ── 24/7 Continuous Monitoring ──────────────────────────────────
+    # Set continuous_monitoring=true to start a recurring schedule
+    # alongside the immediate test run.
+    continuous_monitoring: bool = False
+    monitoring_interval_minutes: int = 60
+    monitoring_device_ids: list[str] | None = None   # defaults to [device_id]
+    monitoring_network_ids: list[str] | None = None   # defaults to [network_id]
+    monitoring_locales: list[str] | None = None       # defaults to [locale]
+    monitoring_personas: list[str | None] | None = None  # defaults to [persona]
+
+
+# ── Endpoints ───────────────────────────────────────────────────────────
+
+
+@app.get("/api/health")
+async def health():
+    """Health check endpoint."""
+    active_schedules = len([s for s in scheduler.list_schedules() if s.is_running])
+    return {
+        "status": "ok",
+        "service": "sentinelbot",
+        "version": "0.3.0",
+        "active_schedules": active_schedules,
+    }
+
+
+@app.get("/api/devices")
+async def api_list_devices():
+    """List all enabled device profiles from the database."""
+    devices = list_devices(enabled_only=True)
+    return [
+        {
+            "id": d["id"],
+            "name": d["name"],
+            "platform": d["platform"],
+            "viewport": f"{d['viewport_width']}x{d['viewport_height']}",
+        }
+        for d in devices
+    ]
+
+
+@app.get("/api/networks")
+async def api_list_networks():
+    """List all enabled network profiles from the database."""
+    networks = list_networks(enabled_only=True)
+    return [
+        {
+            "id": n["id"],
+            "name": n["name"],
+            "latency_ms": n["latency_ms"],
+            "download_kbps": n["download_kbps"],
+            "upload_kbps": n["upload_kbps"],
+        }
+        for n in networks
+    ]
+
+
+@app.post("/api/test")
+async def start_test(req: TestRequest, background_tasks: BackgroundTasks):
+    """Start a new QA test run.
+
+    Requires project_id, device_id, network_id (UUIDs from the database).
+    Returns immediately with a run_id. Poll GET /api/runs/{run_id} for status.
+    """
+    # Validate API key
+    api_key = os.environ.get("ANTHROPIC_API_KEY", "")
+    if not api_key:
+        raise HTTPException(status_code=500, detail="ANTHROPIC_API_KEY is not set")
+
+    # Fetch device and network from DB
+    try:
+        device = get_device_by_id(req.device_id)
+    except Exception:
+        raise HTTPException(status_code=400, detail=f"Device not found: {req.device_id}")
+    try:
+        network = get_network_by_id(req.network_id)
+    except Exception:
+        raise HTTPException(status_code=400, detail=f"Network not found: {req.network_id}")
+
+    # Fetch project to get target_url
+    from sentinel.db.client import get_supabase
+
+    sb = get_supabase()
+    try:
+        project = (
+            sb.table("projects").select("*").eq("id", req.project_id).single().execute()
+        )
+        project_data = project.data
+    except Exception:
+        raise HTTPException(
+            status_code=400, detail=f"Project not found: {req.project_id}"
+        )
+
+    target_url = project_data["target_url"]
+    if not target_url.startswith(("http://", "https://")):
+        target_url = "https://" + target_url
+
+    # Create run row in DB
+    run_row = create_run(
+        project_id=req.project_id,
+        device_id=req.device_id,
+        network_id=req.network_id,
+        locale=req.locale,
+        persona=req.persona,
+    )
+    run_id = run_row["id"]
+
+    # Log run start (mask sensitive values before logging)
+    log_payload = req.model_dump()
+    if req.input_data:
+        log_payload["input_data"] = _mask_input_data(
+            req.input_data, req.sensitive_keys
+        )
+    insert_log(
+        run_id=run_id,
+        level="info",
+        event_type="run_start",
+        message=f"Starting test for {target_url}",
+        payload=log_payload,
+    )
+
+    # Schedule background execution
+    background_tasks.add_task(
+        _execute_run,
+        run_id=run_id,
+        req=req,
+        target_url=target_url,
+        device=device,
+        network=network,
+        project_id=req.project_id,
+        project_data=project_data,
+        api_key=api_key,
+    )
+
+    # ── Optionally start 24/7 continuous monitoring ──────────────
+    schedule_info = None
+    if req.continuous_monitoring:
+        config = ScheduleConfig(
+            project_id=req.project_id,
+            device_ids=req.monitoring_device_ids or [req.device_id],
+            network_ids=req.monitoring_network_ids or [req.network_id],
+            locales=req.monitoring_locales or [req.locale],
+            personas=req.monitoring_personas if req.monitoring_personas is not None else [req.persona],
+            interval_minutes=req.monitoring_interval_minutes,
+            model=req.model,
+            max_tokens=req.max_tokens,
+            thinking_budget=req.thinking_budget,
+            only_n_most_recent_images=req.only_n_most_recent_images,
+            task=req.task,
+            input_data=req.input_data,
+            sensitive_keys=req.sensitive_keys,
+        )
+        state = scheduler.create_schedule(config)
+        combo_count = (
+            len(config.device_ids)
+            * len(config.network_ids)
+            * len(config.locales)
+            * len(config.personas)
+        )
+        scheduler.start_schedule(state.schedule_id, _scheduled_run_trigger)
+        schedule_info = {
+            "schedule_id": state.schedule_id,
+            "combo_count": combo_count,
+            "interval_minutes": req.monitoring_interval_minutes,
+        }
+        insert_log(
+            run_id=run_id,
+            level="info",
+            event_type="continuous_monitoring_started",
+            message=(
+                f"24/7 monitoring enabled: {combo_count} combos every "
+                f"{req.monitoring_interval_minutes}m (schedule {state.schedule_id})"
+            ),
+            payload=schedule_info,
+        )
+        logger.info(
+            f"Run {run_id}: continuous monitoring started — schedule {state.schedule_id}"
+        )
+
+    response = {
+        "run_id": run_id,
+        "status": "running",
+        "detail": f"Test started. Poll GET /api/runs/{run_id} for results.",
+    }
+    if schedule_info:
+        response["continuous_monitoring"] = schedule_info
+    return response
+
+
+@app.get("/api/runs")
+async def api_list_runs(project_id: str | None = None, limit: int = 50):
+    """List recent runs, optionally filtered by project_id."""
+    return db_list_runs(project_id=project_id, limit=limit)
+
+
+@app.get("/api/runs/{run_id}")
+async def api_get_run(run_id: str):
+    """Get detailed results for a specific run, including all intelligence data."""
+    run = db_get_run(run_id)
+    if not run:
+        raise HTTPException(status_code=404, detail="Run not found")
+
+    # Attach issues and evidence
+    issues = get_issues_for_run(run_id)
+    evidence = get_evidence_for_run(run_id)
+
+    # Attach intelligence data from logs
+    from sentinel.db.db_logs import get_logs_for_run
+
+    logs = get_logs_for_run(run_id)
+    ux_confusion = [
+        log.get("payload", {})
+        for log in logs
+        if log.get("event_type") == "ux_confusion"
+    ]
+    locale_issues = [
+        log.get("payload", {})
+        for log in logs
+        if log.get("event_type") == "locale_issue"
+    ]
+    root_cause_matches = [
+        log.get("payload", {})
+        for log in logs
+        if log.get("event_type") == "root_cause_match"
+    ]
+    captcha_logs = [
+        log.get("payload", {})
+        for log in logs
+        if log.get("event_type") == "captcha_encountered"
+    ]
+    a11y_violations = [
+        log.get("payload", {})
+        for log in logs
+        if log.get("event_type") == "a11y_violation"
+    ]
+    regression_events = [
+        log.get("payload", {})
+        for log in logs
+        if log.get("event_type") == "regression_detected"
+    ]
+    flaky_events = [
+        log.get("payload", {})
+        for log in logs
+        if log.get("event_type") in ("flaky_confirmed", "flaky_detected")
+    ]
+
+    # Performance metrics
+    perf_metrics = get_perf_metrics_for_run(run_id)
+
+    return {
+        **run,
+        "issues": issues,
+        "evidence": evidence,
+        "ux_confusion_events": ux_confusion,
+        "locale_issues": locale_issues,
+        "root_cause_matches": root_cause_matches,
+        "captcha_encountered": len(captcha_logs) > 0,
+        "captcha_details": captcha_logs[0] if captcha_logs else None,
+        "accessibility_violations": a11y_violations,
+        "regressions": regression_events,
+        "flaky_detection": flaky_events,
+        "performance_metrics": perf_metrics,
+    }
+
+
+@app.get("/api/runs/{run_id}/issues")
+async def api_get_run_issues(run_id: str):
+    """Get all issues found during a run."""
+    return get_issues_for_run(run_id)
+
+
+@app.get("/api/runs/{run_id}/evidence")
+async def api_get_run_evidence(run_id: str):
+    """Get all evidence (screenshots/videos) for a run."""
+    return get_evidence_for_run(run_id)
+
+
+# ── Background Run Execution ────────────────────────────────────────────
+
+
+async def _execute_run(
+    *,
+    run_id: str,
+    req: TestRequest,
+    target_url: str,
+    device: dict[str, Any],
+    network: dict[str, Any],
+    project_id: str,
+    project_data: dict[str, Any] | None = None,
+    api_key: str,
+):
+    """Execute the Claude sampling loop for a test run."""
+    start_time = time.monotonic()
+    step_counter = {"count": 0}
+
+    # Convert DB rows to Playwright-compatible profile dicts
+    pw_device_profile = device_to_playwright_profile(device)
+    pw_network_profile = network_to_throttle_profile(network)
+
+    # Human-readable labels for the system prompt
+    device_label = f"{device['name']} ({device['viewport_width']}x{device['viewport_height']})"
+    network_label = network["name"]
+
+    # Temp video directory for this run
+    video_dir = os.path.join(VIDEO_TMP_DIR, run_id)
+    os.makedirs(video_dir, exist_ok=True)
+
+    # Initialize PlaywrightComputerTool with DB-sourced profiles
+    pw_tool = PlaywrightComputerTool(
+        device_profile_dict=pw_device_profile,
+        network_profile_dict=pw_network_profile,
+        target_url=target_url,
+        locale=req.locale,
+        video_dir=video_dir,
+    )
+    tool_collection = ToolCollection(pw_tool, BashTool20250124())
+
+    # Build task — always inject the target URL so Claude never asks for it
+    base_task = req.task or (
+        "Thoroughly test the main user flow. "
+        "Try all interactive elements, test form validation, check for visual issues, "
+        "and report all bugs and issues found."
+    )
+    task = f"Navigate to {target_url} and {base_task}"
+
+    # Append user-provided input data to the task so the agent uses them
+    if req.input_data:
+        input_lines = "\n".join(f"  - {k}: {v}" for k, v in req.input_data.items())
+        task += (
+            f"\n\nYou have been provided the following input data to use during testing. "
+            f"Use these values when you encounter corresponding fields (e.g. login forms, "
+            f"search bars, registration fields, etc.):\n{input_lines}"
+        )
+
+    # Build system prompt with persona + locale awareness
+    system_prompt = get_sentinel_system_prompt(
+        device_label=device_label,
+        network_label=network_label,
+        target_url=target_url,
+        persona=req.persona,
+        locale=req.locale,
+    )
+
+    # ── Callbacks ───────────────────────────────────────────────────
+
+    # Track pending tool_use blocks so we can correlate them with results
+    pending_tools: dict[str, dict[str, Any]] = {}   # tool_id → {action, input, start_time}
+    realtime_issues_reported: set[str] = set()       # titles already escalated mid-run
+    last_screenshot_b64: dict[str, str | None] = {"img": None}  # most recent screenshot
+    # Rolling buffer of last 3 screenshots for multi-image Slack uploads
+    recent_screenshots: deque[dict[str, Any]] = deque(maxlen=3)  # [{"b64": ..., "step": ...}]
+
+    # Resolve Slack channel once (reused for all issues in this run)
+    slack_channel_id: dict[str, str | None] = {"id": None}
+    if is_slack_configured():
+        try:
+            slack_channel_id["id"] = await find_or_create_channel(
+                project_name=project_data.get("name", project_id[:8]),
+                project_id=project_id,
+            )
+        except Exception as e:
+            logger.warning(f"Run {run_id}: failed to resolve Slack channel: {e}")
+
+    def _describe_action(tool_input: dict) -> str:
+        """Build a human-readable description from a tool_use input."""
+        action = tool_input.get("action", "unknown")
+        coord = tool_input.get("coordinate")
+        text = tool_input.get("text")
+        scroll_dir = tool_input.get("scroll_direction")
+        scroll_amt = tool_input.get("scroll_amount")
+        duration = tool_input.get("duration")
+        start_coord = tool_input.get("start_coordinate")
+
+        parts = [action]
+        if coord:
+            parts.append(f"at ({coord[0]}, {coord[1]})")
+        if start_coord:
+            parts.append(f"from ({start_coord[0]}, {start_coord[1]})")
+        if text:
+            display = text if len(text) <= 40 else text[:37] + "..."
+            parts.append(f'"{display}"')
+        if scroll_dir:
+            parts.append(f"{scroll_dir} {scroll_amt or 3}x")
+        if duration:
+            parts.append(f"wait {duration}s")
+        return " ".join(parts)
+
+    def output_callback(content_block):
+        """Log assistant output blocks to run_logs + detect real-time issues."""
+        if isinstance(content_block, dict):
+            block_type = content_block.get("type", "unknown")
+            payload: dict[str, Any] = {"block_type": block_type}
+
+            if block_type == "text":
+                text_content = content_block.get("text", "")
+                payload["text"] = text_content
+
+                # ── Real-time issue detection ───────────────────────
+                _check_realtime_issue(
+                    text_content,
+                    run_id=run_id,
+                    project_id=project_id,
+                    target_url=target_url,
+                    device_label=device_label,
+                    network_label=network_label,
+                    slack_channel_id=slack_channel_id["id"],
+                    realtime_issues_reported=realtime_issues_reported,
+                    last_screenshot_b64=last_screenshot_b64["img"],
+                    recent_screenshots=list(recent_screenshots),
+                )
+
+            elif block_type == "tool_use":
+                tool_id = content_block.get("id", "")
+                tool_input = content_block.get("input", {})
+                payload["tool_name"] = content_block.get("name")
+                payload["tool_input"] = tool_input
+                # Stash for correlation with tool_output_callback
+                pending_tools[tool_id] = {
+                    "action": tool_input.get("action", content_block.get("name", "unknown")),
+                    "input": tool_input,
+                    "start_time": time.monotonic(),
+                }
+
+            insert_log(
+                run_id=run_id,
+                level="info",
+                event_type="assistant_output",
+                message=payload.get("text", f"Tool: {payload.get('tool_name', '')}"),
+                payload=payload,
+            )
+
+    def tool_output_callback(result: ToolResult, tool_id: str):
+        """Save screenshots to Supabase Storage, record steps and logs."""
+        step = step_counter["count"]
+        step_counter["count"] += 1
+
+        # Look up the pending tool_use for action details + timing
+        pending = pending_tools.pop(tool_id, None)
+        if pending:
+            action_type = pending["action"]
+            description = _describe_action(pending["input"])
+            duration_ms = int((time.monotonic() - pending["start_time"]) * 1000)
+        else:
+            action_type = "tool_result"
+            description = result.output or result.error or ""
+            duration_ms = None
+
+        # Append error info to description if present
+        if result.error:
+            description = f"{description} [ERROR: {result.error}]" if description else result.error
+
+        # Record the step
+        insert_step(
+            run_id=run_id,
+            step_index=step,
+            action_type=action_type,
+            description=description,
+            duration_ms=duration_ms,
+        )
+
+        # Upload screenshot to Supabase Storage
+        if result.base64_image:
+            last_screenshot_b64["img"] = result.base64_image
+            recent_screenshots.append({"b64": result.base64_image, "step": step})
+            try:
+                upload_screenshot(
+                    run_id=run_id,
+                    step=step,
+                    base64_image=result.base64_image,
+                    label=f"Step {step}",
+                )
+            except Exception as e:
+                logger.warning(f"Run {run_id}: failed to upload screenshot step {step}: {e}")
+
+        # Log the tool result
+        insert_log(
+            run_id=run_id,
+            level="info",
+            event_type="tool_result",
+            message=result.output or result.error or "screenshot",
+            payload={
+                "tool_id": tool_id,
+                "step": step,
+                "has_screenshot": result.base64_image is not None,
+                "error": result.error,
+            },
+        )
+
+    def api_response_callback(request, response, error):
+        """Log API call metadata."""
+        level = "error" if error else "info"
+        payload: dict[str, Any] = {
+            "method": str(request.method),
+            "url": str(request.url),
+        }
+        if error:
+            payload["error"] = str(error)
+            logger.error(f"Run {run_id}: API error: {error}")
+        if isinstance(response, httpx.Response):
+            payload["status_code"] = response.status_code
+            if response.status_code >= 400:
+                level = "error"
+                logger.error(f"Run {run_id}: API returned {response.status_code}")
+
+        insert_log(
+            run_id=run_id,
+            level=level,
+            event_type="api_call",
+            message=f"API {payload['method']} {payload['url']}",
+            payload=payload,
+        )
+
+    # ── Execute ─────────────────────────────────────────────────────
+
+    logger.info(f"Run {run_id}: starting sampling loop for {target_url}")
+
+    try:
+        messages = await sampling_loop(
+            model=req.model,
+            provider=APIProvider.ANTHROPIC,
+            system_prompt_suffix=system_prompt,
+            messages=[{"role": "user", "content": task}],
+            output_callback=output_callback,
+            tool_output_callback=tool_output_callback,
+            api_response_callback=api_response_callback,
+            api_key=api_key,
+            only_n_most_recent_images=req.only_n_most_recent_images,
+            max_tokens=req.max_tokens,
+            tool_version="sentinel_playwright",
+            tool_collection_override=tool_collection,
+            thinking_budget=req.thinking_budget,
+        )
+
+        elapsed_ms = int((time.monotonic() - start_time) * 1000)
+        logger.info(f"Run {run_id}: sampling loop returned {len(messages)} messages in {elapsed_ms}ms")
+
+        # Check if Claude actually responded
+        assistant_msgs = [m for m in messages if m.get("role") == "assistant"]
+        if not assistant_msgs:
+            update_run_failed(run_id, duration_ms=elapsed_ms)
+            insert_log(
+                run_id=run_id,
+                level="error",
+                event_type="run_error",
+                message="No assistant response received from Claude API",
+            )
+            logger.error(f"Run {run_id}: no assistant messages returned")
+            return
+
+        # Warn if Claude didn't use tools (only 2 messages = user + 1 assistant)
+        if len(messages) <= 2 and step_counter["count"] == 0:
+            logger.warning(
+                f"Run {run_id}: Claude responded without using any tools "
+                f"({len(messages)} messages, 0 steps). It may not have tested anything."
+            )
+
+        # Extract structured JSON from Claude's final message
+        raw_summary = _extract_last_text(messages)
+        if raw_summary:
+            logger.info(f"Run {run_id}: raw final response (first 500 chars): {raw_summary[:500]}")
+        else:
+            logger.warning(f"Run {run_id}: no text content in final assistant message")
+        parsed = _parse_structured_output(raw_summary) if raw_summary else None
+
+        # Determine result
+        issues_found = parsed.get("issues", []) if parsed else []
+        run_result = "issue_found" if issues_found else "no_issues"
+
+        # Mark run completed
+        update_run_completed(run_id, result=run_result, duration_ms=elapsed_ms)
+
+        # Persist issues to DB
+        if parsed and issues_found:
+            await _persist_issues(
+                run_id=run_id,
+                project_id=project_id,
+                issues=issues_found,
+                slack_channel_id=slack_channel_id["id"],
+                target_url=target_url,
+                device_label=device_label,
+                network_label=network_label,
+                realtime_issues_reported=realtime_issues_reported,
+                recent_screenshots=list(recent_screenshots),
+            )
+
+        # Persist UX confusion events
+        ux_confusion_events = parsed.get("ux_confusion_events", []) if parsed else []
+        if ux_confusion_events:
+            for event in ux_confusion_events:
+                insert_log(
+                    run_id=run_id,
+                    level="warn",
+                    event_type="ux_confusion",
+                    message=(
+                        f"UX confusion on '{event.get('screen', 'unknown')}': "
+                        f"{event.get('confusion_reason', 'unspecified')}"
+                    ),
+                    payload=event,
+                )
+            logger.info(
+                f"Run {run_id}: {len(ux_confusion_events)} UX confusion events logged"
+            )
+
+        # Persist locale/translation issues
+        locale_issues = parsed.get("locale_issues", []) if parsed else []
+        if locale_issues:
+            for li in locale_issues:
+                insert_log(
+                    run_id=run_id,
+                    level="warn",
+                    event_type="locale_issue",
+                    message=(
+                        f"Locale issue: {li.get('type', 'unknown')} — "
+                        f"found '{li.get('text_found', '')}' "
+                        f"(expected {li.get('expected_language', 'unknown')})"
+                    ),
+                    payload=li,
+                )
+            logger.info(
+                f"Run {run_id}: {len(locale_issues)} locale issues logged"
+            )
+
+        # Log CAPTCHA encounters
+        if parsed and parsed.get("captcha_encountered"):
+            insert_log(
+                run_id=run_id,
+                level="warn",
+                event_type="captcha_encountered",
+                message=f"CAPTCHA/OTP gate encountered: {parsed.get('captcha_details', 'unknown')}",
+                payload={
+                    "captcha_details": parsed.get("captcha_details"),
+                },
+            )
+
+        # Log completion
+        insert_log(
+            run_id=run_id,
+            level="info",
+            event_type="run_complete",
+            message=parsed.get("summary", "Run completed") if parsed else "Run completed",
+            payload={
+                "step_count": step_counter["count"],
+                "issue_count": len(issues_found),
+                "ux_confusion_count": len(ux_confusion_events),
+                "locale_issue_count": len(locale_issues),
+                "captcha_encountered": parsed.get("captcha_encountered", False) if parsed else False,
+                "message_count": len(messages),
+                "tests_passed": parsed.get("tests_passed", []) if parsed else [],
+                "recommendations": parsed.get("recommendations", []) if parsed else [],
+                "duration_ms": elapsed_ms,
+            },
+        )
+
+        # ── Collect perf metrics before closing browser ─────────────
+        # (Capture metrics from the last page visited)
+        try:
+            await pw_tool.collect_perf_metrics(step=step_counter["count"])
+        except Exception as e:
+            logger.debug(f"Run {run_id}: final perf metrics collection: {e}")
+
+        # ── Run a11y audit on current page before browser closes ────
+        try:
+            await pw_tool.run_accessibility_audit(standard="wcag21aa")
+        except Exception as e:
+            logger.debug(f"Run {run_id}: a11y audit: {e}")
+
+        # Upload videos (Playwright saves them on context close)
+        await pw_tool.close()
+        _upload_run_videos(run_id, video_dir)
+
+        # ── Performance Metrics Collection ──────────────────────────
+        try:
+            perf_data = pw_tool.get_perf_metrics()
+            for pm in perf_data:
+                insert_perf_metrics(
+                    run_id=run_id,
+                    url=pm.get("url", target_url),
+                    lcp_ms=pm.get("lcp_ms"),
+                    cls=pm.get("cls"),
+                    ttfb_ms=pm.get("ttfb_ms"),
+                    fcp_ms=pm.get("fcp_ms"),
+                    dom_content_loaded_ms=pm.get("dom_content_loaded_ms"),
+                    resource_count=pm.get("resource_count"),
+                    total_transfer_kb=pm.get("total_transfer_kb"),
+                    step=pm.get("step"),
+                )
+            if perf_data:
+                insert_log(
+                    run_id=run_id,
+                    level="info",
+                    event_type="perf_metrics_collected",
+                    message=f"Collected performance metrics for {len(perf_data)} page(s)",
+                    payload={"metrics_count": len(perf_data), "metrics": perf_data},
+                )
+                logger.info(f"Run {run_id}: persisted {len(perf_data)} perf metric row(s)")
+        except Exception as e:
+            logger.warning(f"Run {run_id}: perf metrics persistence failed: {e}")
+
+        # ── Accessibility Audit (axe-core) ──────────────────────────
+        a11y_issue_count = 0
+        try:
+            a11y_violations = pw_tool.get_a11y_violations()
+            if a11y_violations:
+                a11y_issue_count = await _persist_a11y_violations(
+                    run_id=run_id,
+                    project_id=project_id,
+                    violations=a11y_violations,
+                    target_url=target_url,
+                    device_label=device_label,
+                    network_label=network_label,
+                    slack_channel_id=slack_channel_id["id"],
+                    realtime_issues_reported=realtime_issues_reported,
+                )
+                logger.info(
+                    f"Run {run_id}: {a11y_issue_count} a11y issues created "
+                    f"from {len(a11y_violations)} violations"
+                )
+        except Exception as e:
+            logger.warning(f"Run {run_id}: a11y audit persistence failed: {e}")
+
+        # ── Cross-Run Regression Detection ──────────────────────────
+        regression_count = 0
+        try:
+            regression_count = await _check_regressions(
+                run_id=run_id,
+                project_id=project_id,
+                device_id=req.device_id,
+                network_id=req.network_id,
+                current_issues=issues_found,
+                tests_passed=parsed.get("tests_passed", []) if parsed else [],
+                target_url=target_url,
+                device_label=device_label,
+                network_label=network_label,
+                slack_channel_id=slack_channel_id["id"],
+            )
+            if regression_count:
+                logger.info(f"Run {run_id}: {regression_count} regression(s) detected")
+        except Exception as e:
+            logger.warning(f"Run {run_id}: regression detection failed: {e}")
+
+        # ── Flaky Test Detection (P0/P1 only) ───────────────────────
+        flaky_results = {}
+        try:
+            p0p1_issues = [
+                i for i in issues_found
+                if i.get("severity") in ("P0", "P1")
+                and i.get("title") not in realtime_issues_reported
+            ]
+            if p0p1_issues:
+                flaky_results = await _run_flaky_detection(
+                    run_id=run_id,
+                    project_id=project_id,
+                    req=req,
+                    target_url=target_url,
+                    device=device,
+                    network=network,
+                    project_data=project_data,
+                    api_key=api_key,
+                    p0p1_issues=p0p1_issues,
+                    slack_channel_id=slack_channel_id["id"],
+                )
+        except Exception as e:
+            logger.warning(f"Run {run_id}: flaky detection failed: {e}")
+
+        # ── Slack run summary ───────────────────────────────────────
+        if slack_channel_id["id"]:
+            try:
+                await post_run_summary_to_slack(
+                    channel_id=slack_channel_id["id"],
+                    run_id=run_id,
+                    target_url=target_url,
+                    device_label=device_label,
+                    network_label=network_label,
+                    issue_count=len(issues_found),
+                    step_count=step_counter["count"],
+                    duration_ms=elapsed_ms,
+                    tests_passed=parsed.get("tests_passed", []) if parsed else [],
+                    ux_confusion_count=len(ux_confusion_events),
+                    locale_issue_count=len(locale_issues),
+                    captcha_encountered=parsed.get("captcha_encountered", False) if parsed else False,
+                )
+            except Exception as e:
+                logger.warning(f"Run {run_id}: failed to post Slack run summary: {e}")
+
+        logger.info(
+            f"Run {run_id} completed: {step_counter['count']} steps, "
+            f"{len(issues_found)} issues, {elapsed_ms}ms"
+        )
+
+    except Exception as e:
+        elapsed_ms = int((time.monotonic() - start_time) * 1000)
+        update_run_failed(run_id, duration_ms=elapsed_ms)
+        insert_log(
+            run_id=run_id,
+            level="error",
+            event_type="run_error",
+            message=f"{type(e).__name__}: {e}",
+            payload={"traceback": traceback.format_exc()},
+        )
+        logger.error(f"Run {run_id} failed: {e}", exc_info=True)
+        await pw_tool.close()
+
+
+async def _persist_issues(
+    *,
+    run_id: str,
+    project_id: str,
+    issues: list[dict[str, Any]],
+    slack_channel_id: str | None = None,
+    target_url: str = "",
+    device_label: str = "",
+    network_label: str = "",
+    realtime_issues_reported: set[str] | None = None,
+    recent_screenshots: list[dict[str, Any]] | None = None,
+) -> None:
+    """Create issue rows, link to run, perform root cause analysis, and notify Slack."""
+    for issue_data in issues:
+        try:
+            severity = issue_data.get("severity", "P2")
+            if severity not in ("P0", "P1", "P2", "P3"):
+                severity = "P2"
+
+            # Skip DB creation if already created in real-time
+            title = issue_data.get("title", "Untitled issue")
+            already_reported = realtime_issues_reported and title in realtime_issues_reported
+
+            if already_reported:
+                logger.info(f"Run {run_id}: issue \"{title}\" already reported in real-time, skipping")
+                continue
+
+            # Resolve Slack user for the category owner
+            owner_slack_id = _get_owner_for_category(
+                issue_data.get("category"), project_id=project_id
+            )
+            issue = create_issue(
+                project_id=project_id,
+                title=title,
+                description=issue_data.get("description"),
+                severity=severity,
+                category=issue_data.get("category"),
+                run_id=run_id,
+                slack_user_id=owner_slack_id,
+            )
+            link_issue_to_run(issue["id"], run_id)
+
+            # Link screenshot evidence if screenshot_step is specified
+            screenshot_step = issue_data.get("screenshot_step")
+            if screenshot_step is not None:
+                _link_screenshot_to_issue(run_id, issue["id"], screenshot_step)
+
+            # ── Root Cause Intelligence ─────────────────────────────
+            similar = []
+            try:
+                similar = find_similar_issues(
+                    project_id=project_id,
+                    title=issue_data.get("title", ""),
+                    description=issue_data.get("description"),
+                    threshold=0.35,
+                    max_results=3,
+                    exclude_issue_id=issue["id"],
+                )
+                if similar:
+                    related_ids = [s["id"] for s in similar]
+                    related_titles = [
+                        f"{s['id'][:8]}… ({s['severity']}, score={s['similarity_score']}) \"{s['title']}\""
+                        for s in similar
+                    ]
+                    insert_log(
+                        run_id=run_id,
+                        level="info",
+                        event_type="root_cause_match",
+                        message=(
+                            f"Issue \"{issue_data.get('title')}\" is similar to "
+                            f"{len(similar)} existing issue(s)"
+                        ),
+                        payload={
+                            "new_issue_id": issue["id"],
+                            "similar_issues": related_ids,
+                            "matches": related_titles,
+                            "top_similarity": similar[0]["similarity_score"],
+                        },
+                    )
+                    logger.info(
+                        f"Run {run_id}: issue {issue['id'][:8]}… has {len(similar)} "
+                        f"similar issues (top score: {similar[0]['similarity_score']})"
+                    )
+            except Exception as e:
+                logger.warning(f"Run {run_id}: root cause analysis failed: {e}")
+
+            # ── Slack Notification (end-of-run issues) ──────────────
+            if slack_channel_id:
+                try:
+                    screenshot_b64 = None
+                    if screenshot_step is not None:
+                        screenshot_b64 = _get_screenshot_b64_for_step(run_id, screenshot_step)
+                    await post_issue_to_slack(
+                        channel_id=slack_channel_id,
+                        issue_data=issue_data,
+                        issue_db_row=issue,
+                        run_id=run_id,
+                        target_url=target_url,
+                        device_label=device_label,
+                        network_label=network_label,
+                        project_id=project_id,
+                        screenshot_base64=screenshot_b64,
+                        recent_screenshots=recent_screenshots or [],
+                        similar_issues=similar,
+                        is_realtime=False,
+                    )
+                except Exception as e:
+                    logger.warning(f"Run {run_id}: Slack notification failed: {e}")
+
+            logger.info(f"Run {run_id}: created issue {issue['id']} — {issue_data.get('title')}")
+        except Exception as e:
+            logger.warning(f"Run {run_id}: failed to persist issue: {e}")
+
+
+def _link_screenshot_to_issue(run_id: str, issue_id: str, step: int) -> None:
+    """Find the evidence row for a screenshot step and link it to an issue."""
+    try:
+        from sentinel.db.client import get_supabase
+
+        sb = get_supabase()
+        storage_path = f"{run_id}/step_{step:03d}.png"
+        result = (
+            sb.table("evidence")
+            .select("id")
+            .eq("run_id", run_id)
+            .eq("storage_path", storage_path)
+            .execute()
+        )
+        if result.data:
+            link_evidence_to_issue(result.data[0]["id"], issue_id)
+    except Exception as e:
+        logger.warning(f"Failed to link screenshot step {step} to issue {issue_id}: {e}")
+
+
+def _get_screenshot_b64_for_step(run_id: str, step: int) -> str | None:
+    """Retrieve a screenshot's base64 content from Supabase Storage for Slack upload."""
+    try:
+        import base64 as b64module
+        from sentinel.db.client import get_supabase
+        from sentinel.db.db_evidence import SCREENSHOT_BUCKET
+
+        sb = get_supabase()
+        storage_path = f"{run_id}/step_{step:03d}.png"
+        file_bytes = sb.storage.from_(SCREENSHOT_BUCKET).download(storage_path)
+        if file_bytes:
+            return b64module.b64encode(file_bytes).decode("utf-8")
+    except Exception as e:
+        logger.debug(f"Could not retrieve screenshot for step {step}: {e}")
+    return None
+
+
+def _check_realtime_issue(
+    text: str,
+    *,
+    run_id: str,
+    project_id: str,
+    target_url: str,
+    device_label: str,
+    network_label: str,
+    slack_channel_id: str | None,
+    realtime_issues_reported: set[str],
+    last_screenshot_b64: str | None,
+    recent_screenshots: list[dict[str, Any]] | None = None,
+) -> None:
+    """Parse real-time 🚨 ISSUE_FOUND markers from Claude's text output.
+
+    When found, immediately creates the issue in the DB and sends a Slack notification.
+    This runs synchronously in the output_callback context.
+    """
+    MARKER = "🚨 ISSUE_FOUND:"
+    if MARKER not in text:
+        return
+
+    # May have multiple markers in one text block
+    for line in text.split("\n"):
+        line = line.strip()
+        if not line.startswith(MARKER):
+            continue
+
+        json_str = line[len(MARKER):].strip()
+        try:
+            issue_data = json.loads(json_str)
+        except (json.JSONDecodeError, ValueError):
+            logger.warning(f"Run {run_id}: failed to parse real-time issue JSON: {json_str[:200]}")
+            continue
+
+        title = issue_data.get("title", "Untitled issue")
+        if title in realtime_issues_reported:
+            continue  # Already handled
+        realtime_issues_reported.add(title)
+
+        severity = issue_data.get("severity", "P2")
+        if severity not in ("P0", "P1", "P2", "P3"):
+            severity = "P2"
+
+        logger.info(f"Run {run_id}: ⚡ REAL-TIME issue detected: [{severity}] {title}")
+
+        # Create issue in DB immediately
+        try:
+            owner_slack_id = _get_owner_for_category(
+                issue_data.get("category"), project_id=project_id
+            )
+            issue = create_issue(
+                project_id=project_id,
+                title=title,
+                description=issue_data.get("description"),
+                severity=severity,
+                category=issue_data.get("category"),
+                run_id=run_id,
+                slack_user_id=owner_slack_id,
+            )
+            link_issue_to_run(issue["id"], run_id)
+
+            # Link screenshot if available
+            screenshot_step = issue_data.get("screenshot_step")
+            if screenshot_step is not None:
+                _link_screenshot_to_issue(run_id, issue["id"], screenshot_step)
+
+            insert_log(
+                run_id=run_id,
+                level="warn",
+                event_type="realtime_issue",
+                message=f"⚡ [{severity}] {title}",
+                payload={
+                    "issue_id": issue["id"],
+                    "issue_data": issue_data,
+                    "realtime": True,
+                },
+            )
+
+            # Send Slack notification immediately
+            if slack_channel_id:
+                # Find similar issues for root cause context
+                similar = []
+                try:
+                    similar = find_similar_issues(
+                        project_id=project_id,
+                        title=title,
+                        description=issue_data.get("description"),
+                        threshold=0.35,
+                        max_results=3,
+                        exclude_issue_id=issue["id"],
+                    )
+                except Exception:
+                    pass
+
+                # Get screenshot for Slack — prefer stored, fallback to last captured
+                screenshot_for_slack = None
+                if screenshot_step is not None:
+                    screenshot_for_slack = _get_screenshot_b64_for_step(run_id, screenshot_step)
+                if not screenshot_for_slack:
+                    screenshot_for_slack = last_screenshot_b64
+
+                try:
+                    loop = asyncio.get_event_loop()
+                    loop.create_task(
+                        post_issue_to_slack(
+                            channel_id=slack_channel_id,
+                            issue_data=issue_data,
+                            issue_db_row=issue,
+                            run_id=run_id,
+                            target_url=target_url,
+                            device_label=device_label,
+                            network_label=network_label,
+                            project_id=project_id,
+                            screenshot_base64=screenshot_for_slack,
+                            recent_screenshots=recent_screenshots,
+                            similar_issues=similar,
+                            is_realtime=True,
+                        )
+                    )
+                except Exception as e:
+                    logger.warning(f"Run {run_id}: real-time Slack notification failed: {e}")
+
+        except Exception as e:
+            logger.warning(f"Run {run_id}: failed to persist real-time issue: {e}")
+
+
+def _upload_run_videos(run_id: str, video_dir: str) -> None:
+    """Upload all video files from the temp directory to Supabase Storage."""
+    for video_path in glob.glob(os.path.join(video_dir, "*.webm")):
+        try:
+            upload_video(run_id=run_id, local_path=video_path, label="Session recording")
+            logger.info(f"Run {run_id}: uploaded video {os.path.basename(video_path)}")
+        except Exception as e:
+            logger.warning(f"Run {run_id}: failed to upload video: {e}")
+
+
+# ── Accessibility Audit Persistence ─────────────────────────────────────
+
+
+# Map axe-core impact levels to SentinelBot severities
+_AXE_IMPACT_TO_SEVERITY = {
+    "critical": "P0",
+    "serious": "P1",
+    "moderate": "P2",
+    "minor": "P3",
+}
+
+
+async def _persist_a11y_violations(
+    *,
+    run_id: str,
+    project_id: str,
+    violations: list[dict[str, Any]],
+    target_url: str,
+    device_label: str,
+    network_label: str,
+    slack_channel_id: str | None,
+    realtime_issues_reported: set[str],
+) -> int:
+    """Convert axe-core violations to issues and persist to DB.
+
+    Returns the number of issues created.
+    """
+    created = 0
+    for v in violations:
+        impact = v.get("impact", "minor")
+        severity = _AXE_IMPACT_TO_SEVERITY.get(impact, "P2")
+        title = f"A11y: {v.get('help', v.get('id', 'unknown'))}"
+
+        # Skip if already reported in real-time
+        if title in realtime_issues_reported:
+            continue
+
+        # Build description with affected elements
+        nodes_desc = ""
+        nodes = v.get("nodes", [])
+        if nodes:
+            node_lines = []
+            for n in nodes[:3]:
+                target = n.get("target", ["unknown"])
+                target_str = " > ".join(target) if isinstance(target, list) else str(target)
+                summary = n.get("failureSummary", "")
+                node_lines.append(f"  • {target_str}: {summary}")
+            nodes_desc = "\nAffected elements:\n" + "\n".join(node_lines)
+
+        description = (
+            f"{v.get('description', '')}\n"
+            f"WCAG Rule: {v.get('id', 'unknown')}\n"
+            f"Impact: {impact}\n"
+            f"Help: {v.get('helpUrl', 'N/A')}"
+            f"{nodes_desc}"
+        )
+
+        try:
+            owner_slack_id = _get_owner_for_category(
+                "accessibility", project_id=project_id
+            )
+            issue = create_issue(
+                project_id=project_id,
+                title=title,
+                description=description,
+                severity=severity,
+                category="accessibility",
+                run_id=run_id,
+                slack_user_id=owner_slack_id,
+            )
+            link_issue_to_run(issue["id"], run_id)
+            created += 1
+
+            insert_log(
+                run_id=run_id,
+                level="warn",
+                event_type="a11y_violation",
+                message=f"[{severity}] {title}",
+                payload={
+                    "issue_id": issue["id"],
+                    "axe_rule_id": v.get("id"),
+                    "impact": impact,
+                    "help_url": v.get("helpUrl"),
+                    "node_count": len(nodes),
+                },
+            )
+
+            # Notify Slack
+            if slack_channel_id:
+                try:
+                    await post_issue_to_slack(
+                        channel_id=slack_channel_id,
+                        issue_data={
+                            "title": title,
+                            "description": description,
+                            "severity": severity,
+                            "severity_justification": f"axe-core: {impact} impact WCAG 2.1 AA violation",
+                            "category": "accessibility",
+                            "steps_to_reproduce": [
+                                f"Navigate to {target_url}",
+                                "Run axe-core accessibility audit",
+                                f"Violation: {v.get('id')} ({impact})",
+                            ],
+                            "expected": "Page should pass WCAG 2.1 AA accessibility checks",
+                            "actual": v.get("help", "Accessibility violation detected"),
+                        },
+                        issue_db_row=issue,
+                        run_id=run_id,
+                        target_url=target_url,
+                        device_label=device_label,
+                        network_label=network_label,
+                        project_id=project_id,
+                        is_realtime=False,
+                    )
+                except Exception as e:
+                    logger.warning(f"Run {run_id}: a11y Slack notification failed: {e}")
+
+        except Exception as e:
+            logger.warning(f"Run {run_id}: failed to create a11y issue '{title}': {e}")
+
+    return created
+
+
+# ── Cross-Run Regression Detection ──────────────────────────────────────
+
+
+async def _check_regressions(
+    *,
+    run_id: str,
+    project_id: str,
+    device_id: str,
+    network_id: str,
+    current_issues: list[dict[str, Any]],
+    tests_passed: list[str],
+    target_url: str,
+    device_label: str,
+    network_label: str,
+    slack_channel_id: str | None,
+) -> int:
+    """Compare current run against previous run to detect regressions.
+
+    A regression is detected when:
+    - A test that passed in the previous run now has a matching issue, OR
+    - The previous run had no issues of a certain type but now one appears
+
+    Returns the number of regressions detected.
+    """
+    prev_run = get_previous_run(
+        project_id=project_id,
+        device_id=device_id,
+        network_id=network_id,
+        exclude_run_id=run_id,
+    )
+    if not prev_run:
+        logger.info(f"Run {run_id}: no previous run found for regression comparison")
+        return 0
+
+    prev_run_id = prev_run["id"]
+
+    # Get previous run's issues
+    prev_issues = get_issues_for_run(prev_run_id)
+    prev_issue_titles = {i.get("title", "").lower().strip() for i in prev_issues}
+
+    # Get previous run's logs to find tests_passed
+    from sentinel.db.db_logs import get_logs_for_run
+    prev_logs = get_logs_for_run(prev_run_id)
+    prev_tests_passed: list[str] = []
+    for log in prev_logs:
+        if log.get("event_type") == "run_complete":
+            payload = log.get("payload", {})
+            prev_tests_passed = payload.get("tests_passed", [])
+            break
+
+    if not prev_tests_passed:
+        logger.info(f"Run {run_id}: previous run had no tests_passed data, skipping regression check")
+        return 0
+
+    # Find regressions: tests that passed before but now have matching issues
+    regression_count = 0
+    current_issue_titles_lower = [i.get("title", "").lower().strip() for i in current_issues]
+
+    from sentinel.db.db_issues import _tokenize, _jaccard_similarity
+
+    for passed_test in prev_tests_passed:
+        passed_tokens = _tokenize(passed_test)
+        if not passed_tokens:
+            continue
+
+        # Check if any current issue matches this previously-passing test
+        for issue_data in current_issues:
+            issue_title = issue_data.get("title", "")
+            issue_tokens = _tokenize(issue_title + " " + issue_data.get("description", ""))
+            similarity = _jaccard_similarity(passed_tokens, issue_tokens)
+
+            if similarity >= 0.3:
+                # Regression detected!
+                regression_count += 1
+                regression_title = f"⚠️ REGRESSION: {issue_data.get('title', 'Unknown')}"
+
+                logger.warning(
+                    f"Run {run_id}: REGRESSION — '{passed_test}' passed in run "
+                    f"{prev_run_id[:8]}… but now has issue: {issue_data.get('title')}"
+                )
+
+                # Create regression issue
+                try:
+                    owner_slack_id = _get_owner_for_category(
+                        "regression", project_id=project_id
+                    )
+                    reg_issue = create_issue(
+                        project_id=project_id,
+                        title=regression_title,
+                        description=(
+                            f"This is a regression. The test '{passed_test}' passed in the "
+                            f"previous run ({prev_run_id[:8]}…) but now fails.\n\n"
+                            f"Current issue: {issue_data.get('description', 'N/A')}\n"
+                            f"Previous run: {prev_run_id}\n"
+                            f"Current run: {run_id}\n"
+                            f"Similarity score: {similarity:.3f}"
+                        ),
+                        severity=issue_data.get("severity", "P1"),
+                        category="regression",
+                        run_id=run_id,
+                        slack_user_id=owner_slack_id,
+                    )
+                    link_issue_to_run(reg_issue["id"], run_id)
+
+                    insert_log(
+                        run_id=run_id,
+                        level="error",
+                        event_type="regression_detected",
+                        message=regression_title,
+                        payload={
+                            "regression_issue_id": reg_issue["id"],
+                            "previous_run_id": prev_run_id,
+                            "previously_passed": passed_test,
+                            "current_issue_title": issue_data.get("title"),
+                            "similarity_score": round(similarity, 3),
+                        },
+                    )
+
+                    # Slack notification
+                    if slack_channel_id:
+                        try:
+                            await post_issue_to_slack(
+                                channel_id=slack_channel_id,
+                                issue_data={
+                                    "title": regression_title,
+                                    "description": (
+                                        f"⚠️ *REGRESSION DETECTED*\n\n"
+                                        f"The test *\"{passed_test}\"* passed in the previous run "
+                                        f"(`{prev_run_id[:8]}…`) but now has an issue.\n\n"
+                                        f"*Current issue:* {issue_data.get('description', 'N/A')}"
+                                    ),
+                                    "severity": issue_data.get("severity", "P1"),
+                                    "severity_justification": (
+                                        "Regression — this functionality was working in the previous run"
+                                    ),
+                                    "category": "regression",
+                                    "steps_to_reproduce": issue_data.get("steps_to_reproduce", []),
+                                    "expected": f"Should work as it did in run {prev_run_id[:8]}…",
+                                    "actual": issue_data.get("actual", "Regression observed"),
+                                },
+                                issue_db_row=reg_issue,
+                                run_id=run_id,
+                                target_url=target_url,
+                                device_label=device_label,
+                                network_label=network_label,
+                                project_id=project_id,
+                                is_realtime=False,
+                            )
+                        except Exception as e:
+                            logger.warning(f"Run {run_id}: regression Slack notification failed: {e}")
+
+                except Exception as e:
+                    logger.warning(f"Run {run_id}: failed to create regression issue: {e}")
+
+                break  # One regression per passed_test is enough
+
+    if regression_count:
+        insert_log(
+            run_id=run_id,
+            level="error",
+            event_type="regression_summary",
+            message=f"{regression_count} regression(s) detected vs run {prev_run_id[:8]}…",
+            payload={
+                "regression_count": regression_count,
+                "previous_run_id": prev_run_id,
+                "previous_tests_passed_count": len(prev_tests_passed),
+                "current_issue_count": len(current_issues),
+            },
+        )
+
+    return regression_count
+
+
+# ── Flaky Test Detection ────────────────────────────────────────────────
+
+
+async def _run_flaky_detection(
+    *,
+    run_id: str,
+    project_id: str,
+    req: TestRequest,
+    target_url: str,
+    device: dict[str, Any],
+    network: dict[str, Any],
+    project_data: dict[str, Any] | None,
+    api_key: str,
+    p0p1_issues: list[dict[str, Any]],
+    slack_channel_id: str | None,
+) -> dict[str, Any]:
+    """Run flaky test detection for P0/P1 issues.
+
+    Performs up to 2 verification runs targeting the failing flows.
+    Uses majority vote (2/3) to confirm or mark issues as flaky.
+
+    Returns a summary dict with confirmed and flaky issue counts.
+    """
+    logger.info(
+        f"Run {run_id}: starting flaky detection for {len(p0p1_issues)} P0/P1 issue(s)"
+    )
+
+    insert_log(
+        run_id=run_id,
+        level="info",
+        event_type="flaky_detection_start",
+        message=f"Verifying {len(p0p1_issues)} P0/P1 issues with 2 re-runs",
+        payload={"issues": [i.get("title") for i in p0p1_issues]},
+    )
+
+    # Build a focused verification task
+    issue_descriptions = []
+    for i, issue in enumerate(p0p1_issues[:5], 1):  # Cap at 5 issues
+        issue_descriptions.append(
+            f"{i}. [{issue.get('severity', 'P1')}] {issue.get('title', 'Unknown')}: "
+            f"{issue.get('description', 'No description')[:200]}"
+        )
+    issues_text = "\n".join(issue_descriptions)
+
+    verification_task = (
+        f"Navigate to {target_url} and VERIFY the following issues. "
+        f"For each issue, try to reproduce it using the same steps. "
+        f"Report ONLY these specific issues if you can reproduce them. "
+        f"If an issue does not reproduce, note it in tests_passed.\n\n"
+        f"Issues to verify:\n{issues_text}"
+    )
+
+    # Track reproduction counts per issue title
+    reproduced: dict[str, int] = {i.get("title", ""): 1 for i in p0p1_issues}  # 1 = original run
+    total_attempts: dict[str, int] = {i.get("title", ""): 1 for i in p0p1_issues}
+
+    # Run 2 verification rounds
+    for verification_round in range(1, 3):
+        logger.info(f"Run {run_id}: flaky verification round {verification_round}/2")
+
+        try:
+            # Create a verification run
+            verify_run = create_run(
+                project_id=project_id,
+                device_id=req.device_id,
+                network_id=req.network_id,
+                locale=req.locale,
+                persona=req.persona,
+            )
+            verify_run_id = verify_run["id"]
+
+            insert_log(
+                run_id=verify_run_id,
+                level="info",
+                event_type="flaky_verification_run",
+                message=f"Flaky verification round {verification_round}/2 for run {run_id[:8]}…",
+                payload={"original_run_id": run_id, "round": verification_round},
+            )
+
+            # Set up a minimal Playwright instance for verification
+            pw_device_profile = device_to_playwright_profile(device)
+            pw_network_profile = network_to_throttle_profile(network)
+            verify_video_dir = os.path.join(VIDEO_TMP_DIR, verify_run_id)
+            os.makedirs(verify_video_dir, exist_ok=True)
+
+            verify_pw = PlaywrightComputerTool(
+                device_profile_dict=pw_device_profile,
+                network_profile_dict=pw_network_profile,
+                target_url=target_url,
+                locale=req.locale,
+                video_dir=verify_video_dir,
+            )
+            verify_tool_collection = ToolCollection(verify_pw, BashTool20250124())
+
+            device_label = f"{device['name']} ({device['viewport_width']}x{device['viewport_height']})"
+            network_label = network["name"]
+
+            system_prompt = get_sentinel_system_prompt(
+                device_label=device_label,
+                network_label=network_label,
+                target_url=target_url,
+                persona=req.persona,
+                locale=req.locale,
+            )
+
+            verify_start = time.monotonic()
+
+            messages = await sampling_loop(
+                model=req.model,
+                provider=APIProvider.ANTHROPIC,
+                system_prompt_suffix=system_prompt,
+                messages=[{"role": "user", "content": verification_task}],
+                output_callback=lambda _: None,
+                tool_output_callback=lambda result, tid: None,
+                api_response_callback=lambda req, resp, err: None,
+                api_key=api_key,
+                only_n_most_recent_images=req.only_n_most_recent_images,
+                max_tokens=req.max_tokens,
+                tool_version="sentinel_playwright",
+                tool_collection_override=verify_tool_collection,
+                thinking_budget=req.thinking_budget,
+            )
+
+            verify_elapsed = int((time.monotonic() - verify_start) * 1000)
+            await verify_pw.close()
+
+            # Parse the verification results
+            raw = _extract_last_text(messages)
+            parsed = _parse_structured_output(raw) if raw else None
+
+            if parsed:
+                verify_issues = parsed.get("issues", [])
+                verify_passed = parsed.get("tests_passed", [])
+
+                verify_issue_titles = {i.get("title", "").lower().strip() for i in verify_issues}
+
+                for issue_title in reproduced:
+                    total_attempts[issue_title] = total_attempts.get(issue_title, 1) + 1
+                    # Check if this issue reproduced
+                    issue_tokens = _tokenize(issue_title)
+                    for vi in verify_issues:
+                        vi_tokens = _tokenize(vi.get("title", "") + " " + vi.get("description", ""))
+                        if _jaccard_similarity(issue_tokens, vi_tokens) >= 0.3:
+                            reproduced[issue_title] = reproduced.get(issue_title, 1) + 1
+                            break
+
+                update_run_completed(verify_run_id, result="flaky_verification", duration_ms=verify_elapsed)
+            else:
+                update_run_failed(verify_run_id, duration_ms=verify_elapsed)
+
+        except Exception as e:
+            logger.warning(f"Run {run_id}: flaky verification round {verification_round} failed: {e}")
+
+    # Analyze results — 2/3 majority vote
+    confirmed_issues = []
+    flaky_issues = []
+
+    for issue_data in p0p1_issues:
+        title = issue_data.get("title", "")
+        repro_count = reproduced.get(title, 1)
+        attempt_count = total_attempts.get(title, 1)
+
+        if repro_count >= 2:
+            # Confirmed — reproduced in ≥2 out of 3 runs
+            confirmed_issues.append(title)
+            insert_log(
+                run_id=run_id,
+                level="info",
+                event_type="flaky_confirmed",
+                message=f"✅ CONFIRMED: [{issue_data.get('severity')}] {title} ({repro_count}/{attempt_count} runs)",
+                payload={
+                    "issue_title": title,
+                    "reproduced": repro_count,
+                    "total_attempts": attempt_count,
+                    "confirmed": True,
+                },
+            )
+        else:
+            # Flaky — reproduced in only 1 out of 3 runs
+            flaky_issues.append(title)
+            insert_log(
+                run_id=run_id,
+                level="warn",
+                event_type="flaky_detected",
+                message=f"🔄 FLAKY: [{issue_data.get('severity')}] {title} ({repro_count}/{attempt_count} runs)",
+                payload={
+                    "issue_title": title,
+                    "reproduced": repro_count,
+                    "total_attempts": attempt_count,
+                    "flaky": True,
+                },
+            )
+
+            # Update the issue in DB to mark as flaky (downgrade severity by 1 level)
+            try:
+                from sentinel.db.client import get_supabase
+                sb = get_supabase()
+                severity_downgrade = {
+                    "P0": "P1",
+                    "P1": "P2",
+                }
+                new_severity = severity_downgrade.get(issue_data.get("severity", "P1"), "P2")
+                sb.table("issues").update({
+                    "status": "flaky",
+                    "severity": new_severity,
+                }).eq("title", title).eq("run_id", run_id).execute()
+            except Exception as e:
+                logger.warning(f"Run {run_id}: failed to update flaky issue: {e}")
+
+    # Slack summary for flaky detection
+    if slack_channel_id and (confirmed_issues or flaky_issues):
+        try:
+            from sentinel.slack_notifier import _get_token, _headers, SLACK_API
+            token = _get_token()
+            if token:
+                confirmed_text = "\n".join(f"  ✅ {t}" for t in confirmed_issues) or "  _None_"
+                flaky_text = "\n".join(f"  🔄 {t}" for t in flaky_issues) or "  _None_"
+
+                blocks = [
+                    {
+                        "type": "header",
+                        "text": {
+                            "type": "plain_text",
+                            "text": "🔄 Flaky Test Detection Results",
+                            "emoji": True,
+                        },
+                    },
+                    {
+                        "type": "section",
+                        "text": {
+                            "type": "mrkdwn",
+                            "text": (
+                                f"Verified {len(p0p1_issues)} P0/P1 issues with 2 re-runs "
+                                f"(3 total attempts per issue).\n\n"
+                                f"*Confirmed (≥2/3 reproduced):*\n{confirmed_text}\n\n"
+                                f"*Flaky (1/3 reproduced — severity downgraded):*\n{flaky_text}"
+                            ),
+                        },
+                    },
+                    {
+                        "type": "context",
+                        "elements": [
+                            {"type": "mrkdwn", "text": f"Original run `{run_id[:8]}…`"},
+                        ],
+                    },
+                ]
+
+                async with httpx.AsyncClient() as client:
+                    await client.post(
+                        f"{SLACK_API}/chat.postMessage",
+                        headers=_headers(token),
+                        json={
+                            "channel": slack_channel_id,
+                            "blocks": blocks,
+                            "text": f"🔄 Flaky detection: {len(confirmed_issues)} confirmed, {len(flaky_issues)} flaky",
+                        },
+                    )
+        except Exception as e:
+            logger.warning(f"Run {run_id}: flaky detection Slack summary failed: {e}")
+
+    result = {
+        "confirmed_count": len(confirmed_issues),
+        "flaky_count": len(flaky_issues),
+        "confirmed": confirmed_issues,
+        "flaky": flaky_issues,
+    }
+
+    insert_log(
+        run_id=run_id,
+        level="info",
+        event_type="flaky_detection_complete",
+        message=(
+            f"Flaky detection complete: {len(confirmed_issues)} confirmed, "
+            f"{len(flaky_issues)} flaky"
+        ),
+        payload=result,
+    )
+
+    logger.info(
+        f"Run {run_id}: flaky detection — "
+        f"{len(confirmed_issues)} confirmed, {len(flaky_issues)} flaky"
+    )
+
+    return result
+
+
+# ── Helpers ─────────────────────────────────────────────────────────────
+
+
+def _extract_last_text(messages: list) -> str | None:
+    """Get the text content of the last assistant message."""
+    for msg in reversed(messages):
+        if msg.get("role") == "assistant":
+            content = msg.get("content", [])
+            if isinstance(content, list):
+                for block in content:
+                    if isinstance(block, dict) and block.get("type") == "text":
+                        return block["text"]
+            break
+    return None
+
+
+def _parse_structured_output(text: str) -> dict | None:
+    """Extract structured JSON from Claude's final response.
+
+    Tries multiple strategies:
+    1. JSON inside ```json ... ``` fences (greedy brace matching)
+    2. First top-level { ... } in the text
+    3. The raw text itself as JSON
+    """
+    # Strategy 1: fenced code block
+    match = re.search(r"```(?:json)?\s*\n?(\{.+\})\s*```", text, re.DOTALL)
+    if match:
+        raw = match.group(1)
+        try:
+            data = json.loads(raw)
+            if isinstance(data, dict):
+                return data
+        except (json.JSONDecodeError, ValueError):
+            pass
+
+    # Strategy 2: find the outermost { ... } by brace counting
+    start = text.find("{")
+    if start != -1:
+        depth = 0
+        for i in range(start, len(text)):
+            if text[i] == "{":
+                depth += 1
+            elif text[i] == "}":
+                depth -= 1
+                if depth == 0:
+                    raw = text[start : i + 1]
+                    try:
+                        data = json.loads(raw)
+                        if isinstance(data, dict):
+                            return data
+                    except (json.JSONDecodeError, ValueError):
+                        pass
+                    break
+
+    # Strategy 3: raw text
+    try:
+        data = json.loads(text.strip())
+        if isinstance(data, dict):
+            return data
+    except (json.JSONDecodeError, ValueError):
+        pass
+
+    logger.warning(
+        f"Failed to parse structured JSON from Claude's response. "
+        f"First 300 chars: {text[:300]}"
+    )
+    return None
+
+
+# ── Scheduler Endpoints ─────────────────────────────────────────────────
+
+
+class ScheduleRequest(BaseModel):
+    """Request body for creating a continuous monitoring schedule."""
+
+    project_id: str
+    device_ids: list[str]
+    network_ids: list[str]
+    locales: list[str] = ["en-US"]
+    personas: list[str | None] = [None]
+    interval_minutes: int = 60
+    model: str = "claude-sonnet-4-5-20250929"
+    max_tokens: int = 8192
+    thinking_budget: int | None = None
+    only_n_most_recent_images: int = 3
+    task: str | None = None
+    input_data: dict[str, str] | None = None
+    sensitive_keys: list[str] | None = None
+
+
+@app.post("/api/schedules")
+async def create_schedule(req: ScheduleRequest):
+    """Create and start a continuous monitoring schedule.
+
+    The scheduler will rotate through all combinations of device × network × locale × persona,
+    running one test per interval.
+    """
+    config = ScheduleConfig(
+        project_id=req.project_id,
+        device_ids=req.device_ids,
+        network_ids=req.network_ids,
+        locales=req.locales,
+        personas=req.personas,
+        interval_minutes=req.interval_minutes,
+        model=req.model,
+        max_tokens=req.max_tokens,
+        thinking_budget=req.thinking_budget,
+        only_n_most_recent_images=req.only_n_most_recent_images,
+        task=req.task,
+        input_data=req.input_data,
+        sensitive_keys=req.sensitive_keys,
+    )
+
+    state = scheduler.create_schedule(config)
+
+    # Build the total combo count for the response
+    combo_count = (
+        len(req.device_ids)
+        * len(req.network_ids)
+        * len(req.locales)
+        * len(req.personas)
+    )
+
+    # Start the schedule with a function that triggers _execute_run
+    scheduler.start_schedule(state.schedule_id, _scheduled_run_trigger)
+
+    return {
+        "schedule_id": state.schedule_id,
+        "status": "running",
+        "combo_count": combo_count,
+        "interval_minutes": req.interval_minutes,
+        "detail": f"Schedule created. {combo_count} combos will rotate every {req.interval_minutes}m.",
+    }
+
+
+@app.get("/api/schedules")
+async def list_schedules():
+    """List all schedules (active and stopped)."""
+    return [
+        {
+            "schedule_id": s.schedule_id,
+            "project_id": s.config.project_id,
+            "is_running": s.is_running,
+            "total_runs": s.total_runs,
+            "last_run_at": s.last_run_at,
+            "interval_minutes": s.config.interval_minutes,
+            "created_at": s.created_at,
+        }
+        for s in scheduler.list_schedules()
+    ]
+
+
+@app.get("/api/schedules/{schedule_id}")
+async def get_schedule(schedule_id: str):
+    """Get details of a specific schedule."""
+    state = scheduler.get_schedule(schedule_id)
+    if not state:
+        raise HTTPException(status_code=404, detail="Schedule not found")
+    return {
+        "schedule_id": state.schedule_id,
+        "config": state.config.model_dump(),
+        "is_running": state.is_running,
+        "total_runs": state.total_runs,
+        "current_run_id": state.current_run_id,
+        "last_run_at": state.last_run_at,
+        "next_combo_index": state.next_combo_index,
+        "created_at": state.created_at,
+    }
+
+
+@app.delete("/api/schedules/{schedule_id}")
+async def stop_schedule(schedule_id: str):
+    """Stop and remove a schedule."""
+    state = scheduler.get_schedule(schedule_id)
+    if not state:
+        raise HTTPException(status_code=404, detail="Schedule not found")
+    scheduler.delete_schedule(schedule_id)
+    return {"status": "stopped", "total_runs": state.total_runs}
+
+
+async def _scheduled_run_trigger(
+    *,
+    project_id: str,
+    device_id: str,
+    network_id: str,
+    locale: str,
+    persona: str | None,
+    model: str,
+    max_tokens: int,
+    thinking_budget: int | None,
+    only_n_most_recent_images: int,
+    task: str | None,
+    input_data: dict[str, str] | None = None,
+    sensitive_keys: list[str] | None = None,
+) -> str:
+    """Trigger a test run from the scheduler. Returns the run_id."""
+    api_key = os.environ.get("ANTHROPIC_API_KEY", "")
+    if not api_key:
+        raise RuntimeError("ANTHROPIC_API_KEY is not set")
+
+    device = get_device_by_id(device_id)
+    network = get_network_by_id(network_id)
+
+    from sentinel.db.client import get_supabase
+
+    sb = get_supabase()
+    project = sb.table("projects").select("*").eq("id", project_id).single().execute()
+    target_url = project.data["target_url"]
+    if not target_url.startswith(("http://", "https://")):
+        target_url = "https://" + target_url
+
+    run_row = create_run(
+        project_id=project_id,
+        device_id=device_id,
+        network_id=network_id,
+        locale=locale,
+        persona=persona,
+    )
+    run_id = run_row["id"]
+
+    insert_log(
+        run_id=run_id,
+        level="info",
+        event_type="scheduled_run_start",
+        message=f"Scheduled test for {target_url}",
+        payload={
+            "locale": locale,
+            "persona": persona,
+            "device_id": device_id,
+            "network_id": network_id,
+        },
+    )
+
+    # Build a fake TestRequest for _execute_run
+    req = TestRequest(
+        project_id=project_id,
+        device_id=device_id,
+        network_id=network_id,
+        locale=locale,
+        persona=persona,
+        model=model,
+        max_tokens=max_tokens,
+        thinking_budget=thinking_budget,
+        only_n_most_recent_images=only_n_most_recent_images,
+        task=task,
+        input_data=input_data,
+        sensitive_keys=sensitive_keys,
+    )
+
+    # Run in background (don't await — scheduler controls pacing)
+    import asyncio
+
+    asyncio.create_task(
+        _execute_run(
+            run_id=run_id,
+            req=req,
+            target_url=target_url,
+            device=device,
+            network=network,
+            project_id=project_id,
+            project_data=project.data,
+            api_key=api_key,
+        )
+    )
+
+    return run_id
+
+
+# ── Persona & Intelligence Endpoints ────────────────────────────────────
+
+
+@app.get("/api/personas")
+async def list_personas():
+    """List all available user personas for testing."""
+    return [
+        {"key": key, "label": p["label"], "behavior_summary": p["behavior"][:120] + "..."}
+        for key, p in PERSONA_PROFILES.items()
+    ]
+
+
+@app.get("/api/projects/{project_id}/issues/similar")
+async def find_similar(project_id: str, title: str, description: str | None = None):
+    """Find issues similar to the given title/description (root cause intelligence)."""
+    results = find_similar_issues(
+        project_id=project_id,
+        title=title,
+        description=description,
+        threshold=0.25,
+        max_results=10,
+    )
+    return results
+
+
+@app.get("/api/projects/{project_id}/issues/trends")
+async def issue_trends(project_id: str, days: int = 7):
+    """Get issue frequency/trend analysis for a project.
+
+    Groups similar issues and shows how often they recur.
+    """
+    return get_issue_frequency(
+        project_id=project_id,
+        days=days,
+    )
+
+
+@app.get("/api/runs/{run_id}/ux-confusion")
+async def get_ux_confusion_events(run_id: str):
+    """Get UX confusion events detected during a run."""
+    from sentinel.db.db_logs import get_logs_for_run
+
+    logs = get_logs_for_run(run_id)
+    return [
+        {
+            "timestamp": log["ts"],
+            "message": log.get("message"),
+            **(log.get("payload") or {}),
+        }
+        for log in logs
+        if log.get("event_type") == "ux_confusion"
+    ]
+
+
+@app.get("/api/runs/{run_id}/locale-issues")
+async def get_locale_issues(run_id: str):
+    """Get localisation/translation issues detected during a run."""
+    from sentinel.db.db_logs import get_logs_for_run
+
+    logs = get_logs_for_run(run_id)
+    return [
+        {
+            "timestamp": log["ts"],
+            "message": log.get("message"),
+            **(log.get("payload") or {}),
+        }
+        for log in logs
+        if log.get("event_type") == "locale_issue"
+    ]
+
+
+@app.get("/api/runs/{run_id}/root-causes")
+async def get_root_cause_matches(run_id: str):
+    """Get root cause intelligence matches for issues found in a run."""
+    from sentinel.db.db_logs import get_logs_for_run
+
+    logs = get_logs_for_run(run_id)
+    return [
+        {
+            "timestamp": log["ts"],
+            "message": log.get("message"),
+            **(log.get("payload") or {}),
+        }
+        for log in logs
+        if log.get("event_type") == "root_cause_match"
+    ]
+
+
+@app.get("/api/runs/{run_id}/performance")
+async def get_run_performance(run_id: str):
+    """Get Core Web Vitals and resource timing metrics collected during a run."""
+    metrics = get_perf_metrics_for_run(run_id)
+    if not metrics:
+        return {"run_id": run_id, "metrics": [], "detail": "No performance metrics collected"}
+    return {"run_id": run_id, "metrics": metrics}
+
+
+@app.get("/api/projects/{project_id}/performance/trends")
+async def get_perf_trends_endpoint(project_id: str, days: int = 7):
+    """Get performance metric trends for a project over time."""
+    from sentinel.db.db_perf import get_perf_trends
+    return get_perf_trends(project_id=project_id, days=days)
+
+
+@app.get("/api/runs/{run_id}/accessibility")
+async def get_run_accessibility(run_id: str):
+    """Get accessibility (axe-core WCAG 2.1 AA) violations detected during a run."""
+    from sentinel.db.db_logs import get_logs_for_run
+
+    logs = get_logs_for_run(run_id)
+    violations = [
+        {
+            "timestamp": log["ts"],
+            "message": log.get("message"),
+            **(log.get("payload") or {}),
+        }
+        for log in logs
+        if log.get("event_type") == "a11y_violation"
+    ]
+    return {"run_id": run_id, "violation_count": len(violations), "violations": violations}
+
+
+@app.get("/api/runs/{run_id}/regressions")
+async def get_run_regressions(run_id: str):
+    """Get cross-run regression detection results for a run."""
+    from sentinel.db.db_logs import get_logs_for_run
+
+    logs = get_logs_for_run(run_id)
+    regressions = [
+        {
+            "timestamp": log["ts"],
+            "message": log.get("message"),
+            **(log.get("payload") or {}),
+        }
+        for log in logs
+        if log.get("event_type") in ("regression_detected", "regression_summary")
+    ]
+    return {"run_id": run_id, "regressions": regressions}
+
+
+@app.get("/api/runs/{run_id}/flaky")
+async def get_run_flaky(run_id: str):
+    """Get flaky test detection results for a run."""
+    from sentinel.db.db_logs import get_logs_for_run
+
+    logs = get_logs_for_run(run_id)
+    flaky_events = [
+        {
+            "timestamp": log["ts"],
+            "message": log.get("message"),
+            **(log.get("payload") or {}),
+        }
+        for log in logs
+        if log.get("event_type") in ("flaky_detection_start", "flaky_confirmed",
+                                      "flaky_detected", "flaky_detection_complete")
+    ]
+    return {"run_id": run_id, "flaky_detection": flaky_events}
+
+
+# ── Slack Integration Endpoints ──────────────────────────────────────
+
+
+@app.get("/api/slack/status")
+async def slack_status():
+    """Check if Slack integration is configured and working."""
+    configured = is_slack_configured()
+    return {
+        "configured": configured,
+        "detail": (
+            "SLACK_BOT_TOKEN is set. Slack notifications are active."
+            if configured
+            else "SLACK_BOT_TOKEN not set. Set it to enable Slack escalation."
+        ),
+    }
+
+
+class SlackOwnerMapping(BaseModel):
+    """Map issue categories to Slack user IDs for @mention routing."""
+    frontend: str | None = None
+    backend: str | None = None
+    ux: str | None = None
+    performance: str | None = None
+    integration: str | None = None
+
+
+@app.post("/api/slack/owners")
+async def set_slack_owners(mapping: SlackOwnerMapping):
+    """Set category → Slack user ID mapping for issue routing.
+
+    Pass Slack user IDs (e.g., U12345678) for each category.
+    Issues in that category will @mention the corresponding user.
+    """
+    owner_map = {k: v for k, v in mapping.model_dump().items() if v}
+
+    # Store in env vars for this process
+    for category, user_id in owner_map.items():
+        os.environ[f"SLACK_OWNER_{category.upper()}"] = user_id
+
+    return {
+        "status": "ok",
+        "owners_set": owner_map,
+        "detail": "Owner mappings updated. Issues will @mention these users.",
+    }
+
+
+@app.get("/api/slack/owners")
+async def get_slack_owners():
+    """Get current category → Slack user ID mapping."""
+    categories = ["frontend", "backend", "ux", "performance", "integration"]
+    owners = {}
+    for cat in categories:
+        env_key = f"SLACK_OWNER_{cat.upper()}"
+        owners[cat] = os.environ.get(env_key)
+    return owners

--- a/sentinelbot/sentinel/slack_notifier.py
+++ b/sentinelbot/sentinel/slack_notifier.py
@@ -1,0 +1,621 @@
+from __future__ import annotations
+
+import asyncio
+import base64
+import io
+import logging
+import os
+from typing import Any
+
+import httpx
+
+logger = logging.getLogger(__name__)
+
+SLACK_API = "https://slack.com/api"
+
+DEFAULT_CATEGORY_OWNERS: dict[str, str | None] = {
+    "frontend": None,
+    "backend": None,
+    "ux": None,
+    "performance": None,
+    "integration": None,
+}
+
+# Claude's output categories → DB category names (for fallback resolution)
+# Claude reports: functional, visual, performance, accessibility, mobile
+# DB now supports both sets directly. This alias map is a fallback
+# in case a category doesn't have a direct DB entry.
+CATEGORY_ALIAS: dict[str, str] = {
+    "functional": "backend",
+    "visual": "frontend",
+    "accessibility": "ux",
+    "mobile": "frontend",
+}
+
+
+def _get_token() -> str | None:
+    return os.environ.get("SLACK_BOT_TOKEN")
+
+
+def _headers(token: str) -> dict[str, str]:
+    return {
+        "Authorization": f"Bearer {token}",
+        "Content-Type": "application/json; charset=utf-8",
+    }
+
+
+def _get_owner_for_category(category: str | None, project_id: str | None = None) -> str | None:
+    """Resolve the Slack user ID for an issue category.
+
+    Maps Claude's output categories (functional, visual, etc.) to DB categories
+    (backend, frontend, etc.) then looks up the owner.
+    Checks env vars first, then slack_category_owners, then slack_integrations.
+    """
+    if not category:
+        return None
+
+    # Try exact category first, then alias fallback
+    categories_to_try = [category]
+    alias = CATEGORY_ALIAS.get(category)
+    if alias and alias != category:
+        categories_to_try.append(alias)
+
+    for cat in categories_to_try:
+        env_key = f"SLACK_OWNER_{cat.upper()}"
+        owner = os.environ.get(env_key)
+        if owner:
+            return owner
+
+    # Try the dedicated slack_category_owners table (project-scoped)
+    for cat in categories_to_try:
+        try:
+            from sentinel.db.client import get_supabase
+            sb = get_supabase()
+            query = (
+                sb.table("slack_category_owners")
+                .select("slack_user_id")
+                .eq("category", cat)
+            )
+            if project_id:
+                query = query.eq("project_id", project_id)
+            result = query.limit(1).execute()
+            if result.data and result.data[0].get("slack_user_id"):
+                return result.data[0]["slack_user_id"]
+        except Exception:
+            pass
+
+    # Fallback: slack_integrations JSON blob
+    try:
+        from sentinel.db.client import get_supabase
+        sb = get_supabase()
+        query = sb.table("slack_integrations").select("category_owners")
+        if project_id:
+            query = query.eq("project_id", project_id)
+        result = query.limit(1).execute()
+        if result.data:
+            owners = result.data[0].get("category_owners") or {}
+            for cat in categories_to_try:
+                if owners.get(cat):
+                    return owners[cat]
+    except Exception:
+        pass
+
+    for cat in categories_to_try:
+        if DEFAULT_CATEGORY_OWNERS.get(cat):
+            return DEFAULT_CATEGORY_OWNERS[cat]
+    return None
+
+
+# ── Channel Management ──────────────────────────────────────────────────
+
+
+def _get_slack_user_ids_from_db() -> list[str]:
+    """Fetch all active Slack user IDs from the slack_users table."""
+    try:
+        from sentinel.db.client import get_supabase
+        sb = get_supabase()
+        result = (
+            sb.table("slack_users")
+            .select("slack_user_id")
+            .eq("is_active", True)
+            .execute()
+        )
+        return [row["slack_user_id"] for row in (result.data or []) if row.get("slack_user_id")]
+    except Exception as e:
+        logger.warning(f"Slack: could not fetch users from DB: {e}")
+        return []
+
+
+async def _invite_users_to_channel(
+    client: httpx.AsyncClient,
+    token: str,
+    channel_id: str,
+    channel_name: str,
+) -> None:
+    """Invite all active slack_users from the DB to a channel."""
+    user_ids = _get_slack_user_ids_from_db()
+    if not user_ids:
+        logger.info(
+            f"Slack: no active users in slack_users table — "
+            f"channel #{channel_name} created but no users invited."
+        )
+        return
+
+    for user_id in user_ids:
+        resp = await client.post(
+            f"{SLACK_API}/conversations.invite",
+            headers=_headers(token),
+            json={"channel": channel_id, "users": user_id},
+        )
+        data = resp.json()
+        if data.get("ok"):
+            logger.info(f"Slack: invited {user_id} to #{channel_name}")
+        elif data.get("error") == "already_in_channel":
+            logger.debug(f"Slack: {user_id} already in #{channel_name}")
+        else:
+            logger.warning(f"Slack: failed to invite {user_id}: {data.get('error')}")
+
+
+def _slugify(name: str) -> str:
+    """Convert a project name to a Slack-safe channel name."""
+    import re
+    slug = re.sub(r"[^a-z0-9-]", "-", name.lower())
+    slug = re.sub(r"-+", "-", slug).strip("-")
+    return slug[:76]  # Slack max channel name length is 80, leave room for prefix
+
+
+async def find_or_create_channel(
+    project_name: str,
+    project_id: str,
+) -> str | None:
+    """Find or create #sentinel-{project} channel. Returns channel ID or None."""
+    token = _get_token()
+    if not token:
+        logger.debug("Slack: no SLACK_BOT_TOKEN set, skipping")
+        return None
+
+    channel_name = f"sentinel-{_slugify(project_name)}"
+
+    async with httpx.AsyncClient() as client:
+        # Search existing channels (public only — private requires groups:read scope)
+        resp = await client.get(
+            f"{SLACK_API}/conversations.list",
+            headers=_headers(token),
+            params={"types": "public_channel", "limit": 1000, "exclude_archived": "true"},
+        )
+        data = resp.json()
+        if data.get("ok"):
+            for ch in data.get("channels", []):
+                if ch["name"] == channel_name:
+                    logger.info(f"Slack: found existing channel #{channel_name} ({ch['id']})")
+                    # Ensure all DB users are invited
+                    await _invite_users_to_channel(client, token, ch["id"], channel_name)
+                    return ch["id"]
+
+        # Create new channel
+        resp = await client.post(
+            f"{SLACK_API}/conversations.create",
+            headers=_headers(token),
+            json={"name": channel_name},
+        )
+        data = resp.json()
+        if data.get("ok"):
+            channel_id = data["channel"]["id"]
+            logger.info(f"Slack: created channel #{channel_name} ({channel_id})")
+
+            # Set channel topic
+            await client.post(
+                f"{SLACK_API}/conversations.setTopic",
+                headers=_headers(token),
+                json={
+                    "channel": channel_id,
+                    "topic": f"SentinelBot QA alerts for project {project_id[:8]}…",
+                },
+            )
+
+            # Invite users so they can see the channel
+            await _invite_users_to_channel(client, token, channel_id, channel_name)
+
+            return channel_id
+        elif data.get("error") == "name_taken":
+            # Channel exists but bot isn't a member — search all channels
+            logger.info(f"Slack: channel #{channel_name} exists but bot not a member, searching...")
+            resp = await client.get(
+                f"{SLACK_API}/conversations.list",
+                headers=_headers(token),
+                params={
+                    "types": "public_channel,private_channel",
+                    "limit": 1000,
+                    "exclude_archived": "true",
+                },
+            )
+            all_data = resp.json()
+            channel_id = None
+            if all_data.get("ok"):
+                for ch in all_data.get("channels", []):
+                    if ch["name"] == channel_name:
+                        channel_id = ch["id"]
+                        break
+
+            if channel_id:
+                # Join the channel
+                await client.post(
+                    f"{SLACK_API}/conversations.join",
+                    headers=_headers(token),
+                    json={"channel": channel_id},
+                )
+                logger.info(f"Slack: joined existing channel #{channel_name} ({channel_id})")
+                # Invite DB users
+                await _invite_users_to_channel(client, token, channel_id, channel_name)
+                return channel_id
+            else:
+                logger.warning(f"Slack: channel #{channel_name} exists but could not be found via API")
+                return None
+        else:
+            logger.warning(f"Slack: failed to create channel: {data.get('error')}")
+            return None
+
+
+# ── Issue Posting ────────────────────────────────────────────────────────
+
+SEVERITY_EMOJI = {
+    "P0": "🔴",
+    "P1": "🟠",
+    "P2": "🟡",
+    "P3": "🟢",
+}
+
+SEVERITY_LABEL = {
+    "P0": "Showstopper",
+    "P1": "Critical",
+    "P2": "Major",
+    "P3": "Minor",
+}
+
+
+async def post_issue_to_slack(
+    *,
+    channel_id: str,
+    issue_data: dict[str, Any],
+    issue_db_row: dict[str, Any],
+    run_id: str,
+    target_url: str,
+    device_label: str,
+    network_label: str,
+    project_id: str | None = None,
+    screenshot_base64: str | None = None,
+    recent_screenshots: list[dict[str, Any]] | None = None,
+    similar_issues: list[dict[str, Any]] | None = None,
+    is_realtime: bool = False,
+) -> str | None:
+    """Post a rich issue message to Slack, returns the message timestamp (thread_ts).
+
+    Args:
+        channel_id: Slack channel ID
+        issue_data: Raw issue dict from Claude's output
+        issue_db_row: The created issue row from the DB
+        run_id: The run that found this issue
+        target_url: URL being tested
+        device_label: Device name
+        network_label: Network condition
+        screenshot_base64: Optional primary screenshot to upload
+        recent_screenshots: Last 2-3 screenshots [{"b64": ..., "step": ...}]
+            uploaded as threaded replies for context
+        similar_issues: Related issues from root cause analysis
+        is_realtime: Whether this was detected mid-run (vs end-of-run)
+    """
+    token = _get_token()
+    if not token or not channel_id:
+        return None
+
+    severity = issue_data.get("severity", "P2")
+    emoji = SEVERITY_EMOJI.get(severity, "⚪")
+    label = SEVERITY_LABEL.get(severity, "Unknown")
+    title = issue_data.get("title", "Untitled issue")
+    category = issue_data.get("category", "unknown")
+    issue_id = issue_db_row.get("id", "unknown")
+
+    # Build the owner mention
+    owner_id = _get_owner_for_category(category, project_id=project_id)
+    owner_mention = f" → <@{owner_id}>" if owner_id else ""
+
+    # Build reproduction steps
+    steps = issue_data.get("steps_to_reproduce", [])
+    steps_text = "\n".join(f"  {i+1}. {s}" for i, s in enumerate(steps)) if steps else "_No steps provided_"
+
+    # Real-time badge
+    rt_badge = "  ⚡ *LIVE DETECTION*" if is_realtime else ""
+
+    # Root cause section
+    root_cause_text = ""
+    if similar_issues:
+        matches = []
+        for s in similar_issues[:3]:
+            matches.append(
+                f"• `{s['id'][:8]}…` ({s['severity']}) — _{s['title']}_ "
+                f"(similarity: {s.get('similarity_score', '?')})"
+            )
+        root_cause_text = (
+            "\n\n🔗 *Possibly Related Issues:*\n" + "\n".join(matches)
+        )
+
+    blocks = [
+        {
+            "type": "header",
+            "text": {
+                "type": "plain_text",
+                "text": f"{emoji} [{severity}] {title}",
+                "emoji": True,
+            },
+        },
+        {
+            "type": "section",
+            "fields": [
+                {"type": "mrkdwn", "text": f"*Severity:* {emoji} {label}{rt_badge}"},
+                {"type": "mrkdwn", "text": f"*Category:* {category}{owner_mention}"},
+                {"type": "mrkdwn", "text": f"*Device:* {device_label}"},
+                {"type": "mrkdwn", "text": f"*Network:* {network_label}"},
+                {"type": "mrkdwn", "text": f"*URL:* <{target_url}>"},
+                {"type": "mrkdwn", "text": f"*Issue ID:* `{issue_id[:8]}…`"},
+            ],
+        },
+        {
+            "type": "section",
+            "text": {
+                "type": "mrkdwn",
+                "text": f"*Description:*\n{issue_data.get('description', '_No description_')}",
+            },
+        },
+        {
+            "type": "section",
+            "text": {
+                "type": "mrkdwn",
+                "text": (
+                    f"*Expected:* {issue_data.get('expected', '_N/A_')}\n"
+                    f"*Actual:* {issue_data.get('actual', '_N/A_')}"
+                ),
+            },
+        },
+        {
+            "type": "section",
+            "text": {
+                "type": "mrkdwn",
+                "text": f"*Steps to Reproduce:*\n{steps_text}",
+            },
+        },
+    ]
+
+    # Severity justification
+    justification = issue_data.get("severity_justification")
+    if justification:
+        blocks.append({
+            "type": "context",
+            "elements": [
+                {"type": "mrkdwn", "text": f"💡 *Severity rationale:* {justification}"},
+            ],
+        })
+
+    # Root cause matches
+    if root_cause_text:
+        blocks.append({
+            "type": "section",
+            "text": {"type": "mrkdwn", "text": root_cause_text},
+        })
+
+    # Footer
+    blocks.append({
+        "type": "context",
+        "elements": [
+            {"type": "mrkdwn", "text": f"Run `{run_id[:8]}…` | Issue `{issue_id[:8]}…`"},
+        ],
+    })
+
+    async with httpx.AsyncClient() as client:
+        # Post main message
+        resp = await client.post(
+            f"{SLACK_API}/chat.postMessage",
+            headers=_headers(token),
+            json={
+                "channel": channel_id,
+                "blocks": blocks,
+                "text": f"{emoji} [{severity}] {title}",  # fallback for notifications
+            },
+        )
+        data = resp.json()
+        if not data.get("ok"):
+            logger.warning(f"Slack: failed to post issue: {data.get('error')}")
+            return None
+
+        thread_ts = data["ts"]
+        logger.info(f"Slack: posted issue {issue_id[:8]}… to channel {channel_id}")
+
+        # Get permalink URL for this message
+        slack_url = None
+        try:
+            permalink_resp = await client.get(
+                f"{SLACK_API}/chat.getPermalink",
+                headers=_headers(token),
+                params={"channel": channel_id, "message_ts": thread_ts},
+            )
+            permalink_data = permalink_resp.json()
+            if permalink_data.get("ok"):
+                slack_url = permalink_data["permalink"]
+                logger.info(f"Slack: permalink for issue {issue_id[:8]}…: {slack_url}")
+        except Exception as e:
+            logger.warning(f"Slack: failed to get permalink: {e}")
+
+        # Save slack_url to the issue in DB
+        if slack_url and issue_id != "unknown":
+            try:
+                from sentinel.db.client import get_supabase
+                sb = get_supabase()
+                sb.table("issues").update({"slack_url": slack_url}).eq("id", issue_id).execute()
+                logger.info(f"Slack: saved slack_url for issue {issue_id[:8]}…")
+            except Exception as e:
+                logger.warning(f"Slack: failed to save slack_url to DB: {e}")
+
+        # Upload screenshot(s) as threaded replies
+        # Collect all screenshots to upload: primary + recent context
+        screenshots_to_upload: list[dict[str, Any]] = []
+
+        if recent_screenshots:
+            # Use recent screenshots (last 2-3 leading up to the issue)
+            # Deduplicate: if screenshot_base64 matches one in recent, skip it
+            seen_steps = set()
+            for ss in recent_screenshots:
+                step_num = ss.get("step", "?")
+                if step_num not in seen_steps:
+                    seen_steps.add(step_num)
+                    screenshots_to_upload.append(ss)
+        elif screenshot_base64:
+            # Fallback: single screenshot only
+            screenshots_to_upload.append({"b64": screenshot_base64, "step": "?"})
+
+        if screenshots_to_upload:
+            # Brief delay so the main message is fully posted before images
+            await asyncio.sleep(2)
+            for i, ss in enumerate(screenshots_to_upload):
+                step_label = f"Step {ss['step']}" if ss.get('step') != '?' else 'Evidence'
+                await _upload_screenshot_to_thread(
+                    client, token, channel_id, thread_ts,
+                    ss["b64"],
+                    title=f"{step_label} — {title}",
+                    severity=severity,
+                )
+                # Small delay between uploads to preserve order in thread
+                if i < len(screenshots_to_upload) - 1:
+                    await asyncio.sleep(1)
+
+        return thread_ts
+
+
+async def _upload_screenshot_to_thread(
+    client: httpx.AsyncClient,
+    token: str,
+    channel_id: str,
+    thread_ts: str,
+    screenshot_base64: str,
+    title: str,
+    severity: str,
+) -> None:
+    """Upload a screenshot as a file to a Slack thread."""
+    try:
+        image_bytes = base64.b64decode(screenshot_base64)
+
+        # Step 1: Get upload URL
+        resp = await client.post(
+            f"{SLACK_API}/files.getUploadURLExternal",
+            headers={"Authorization": f"Bearer {token}"},
+            data={
+                "filename": f"evidence_{severity}_{title[:30].replace(' ', '_')}.png",
+                "length": len(image_bytes),
+            },
+        )
+        data = resp.json()
+        if not data.get("ok"):
+            logger.warning(f"Slack: failed to get upload URL: {data.get('error')}")
+            return
+
+        upload_url = data["upload_url"]
+        file_id = data["file_id"]
+
+        # Step 2: Upload file bytes
+        await client.post(
+            upload_url,
+            content=image_bytes,
+            headers={"Content-Type": "application/octet-stream"},
+        )
+
+        # Step 3: Complete upload + share to channel thread
+        resp = await client.post(
+            f"{SLACK_API}/files.completeUploadExternal",
+            headers=_headers(token),
+            json={
+                "files": [{"id": file_id, "title": f"📸 Evidence: {title}"}],
+                "channel_id": channel_id,
+                "thread_ts": thread_ts,
+                "initial_comment": f"📸 Screenshot evidence for [{severity}] {title}",
+            },
+        )
+        data = resp.json()
+        if data.get("ok"):
+            logger.info(f"Slack: uploaded screenshot to thread {thread_ts}")
+        else:
+            logger.warning(f"Slack: failed to complete upload: {data.get('error')}")
+
+    except Exception as e:
+        logger.warning(f"Slack: screenshot upload failed: {e}")
+
+
+async def post_run_summary_to_slack(
+    *,
+    channel_id: str,
+    run_id: str,
+    target_url: str,
+    device_label: str,
+    network_label: str,
+    issue_count: int,
+    step_count: int,
+    duration_ms: int,
+    tests_passed: list[str],
+    ux_confusion_count: int = 0,
+    locale_issue_count: int = 0,
+    captcha_encountered: bool = False,
+) -> None:
+    """Post a run completion summary to the Slack channel."""
+    token = _get_token()
+    if not token or not channel_id:
+        return
+
+    duration_s = duration_ms / 1000
+    status_emoji = "✅" if issue_count == 0 else f"🚨 {issue_count} issue(s)"
+
+    summary_lines = [
+        f"*Run Complete:* `{run_id[:8]}…`",
+        f"*URL:* <{target_url}>",
+        f"*Device:* {device_label} | *Network:* {network_label}",
+        f"*Duration:* {duration_s:.1f}s | *Steps:* {step_count}",
+        f"*Result:* {status_emoji}",
+    ]
+    if ux_confusion_count:
+        summary_lines.append(f"*UX Confusion Events:* {ux_confusion_count}")
+    if locale_issue_count:
+        summary_lines.append(f"*Locale Issues:* {locale_issue_count}")
+    if captcha_encountered:
+        summary_lines.append("⚠️ CAPTCHA/OTP gate encountered")
+    if tests_passed:
+        passed_str = ", ".join(tests_passed[:5])
+        if len(tests_passed) > 5:
+            passed_str += f" (+{len(tests_passed) - 5} more)"
+        summary_lines.append(f"*Tests Passed:* {passed_str}")
+
+    blocks = [
+        {
+            "type": "section",
+            "text": {
+                "type": "mrkdwn",
+                "text": "\n".join(summary_lines),
+            },
+        },
+    ]
+
+    async with httpx.AsyncClient() as client:
+        resp = await client.post(
+            f"{SLACK_API}/chat.postMessage",
+            headers=_headers(token),
+            json={
+                "channel": channel_id,
+                "blocks": blocks,
+                "text": f"Run {run_id[:8]}… complete: {status_emoji}",
+            },
+        )
+        data = resp.json()
+        if data.get("ok"):
+            logger.info(f"Slack: posted run summary for {run_id[:8]}…")
+        else:
+            logger.warning(f"Slack: failed to post run summary: {data.get('error')}")
+
+
+def is_slack_configured() -> bool:
+    """Check if Slack integration is available."""
+    return bool(_get_token())

--- a/sentinelbot/sentinel/tools/__init__.py
+++ b/sentinelbot/sentinel/tools/__init__.py
@@ -1,0 +1,15 @@
+from .base import CLIResult, ToolResult
+from .bash import BashTool20250124
+from .collection import ToolCollection
+from .playwright_tool import PlaywrightComputerTool
+from .groups import TOOL_GROUPS_BY_VERSION, ToolVersion
+
+__ALL__ = [
+    BashTool20250124,
+    CLIResult,
+    PlaywrightComputerTool,
+    TOOL_GROUPS_BY_VERSION,
+    ToolCollection,
+    ToolResult,
+    ToolVersion,
+]

--- a/sentinelbot/sentinel/tools/base.py
+++ b/sentinelbot/sentinel/tools/base.py
@@ -1,0 +1,69 @@
+from abc import ABCMeta, abstractmethod
+from dataclasses import dataclass, fields, replace
+from typing import Any
+
+from anthropic.types.beta import BetaToolUnionParam
+
+
+class BaseAnthropicTool(metaclass=ABCMeta):
+    """Abstract base class for Anthropic-defined tools."""
+
+    @abstractmethod
+    def __call__(self, **kwargs) -> Any:
+        """Executes the tool with the given arguments."""
+        ...
+
+    @abstractmethod
+    def to_params(
+        self,
+    ) -> BetaToolUnionParam:
+        raise NotImplementedError
+
+
+@dataclass(kw_only=True, frozen=True)
+class ToolResult:
+    """Represents the result of a tool execution."""
+
+    output: str | None = None
+    error: str | None = None
+    base64_image: str | None = None
+    system: str | None = None
+
+    def __bool__(self):
+        return any(getattr(self, field.name) for field in fields(self))
+
+    def __add__(self, other: "ToolResult"):
+        def combine_fields(
+            field: str | None, other_field: str | None, concatenate: bool = True
+        ):
+            if field and other_field:
+                if concatenate:
+                    return field + other_field
+                raise ValueError("Cannot combine tool results")
+            return field or other_field
+
+        return ToolResult(
+            output=combine_fields(self.output, other.output),
+            error=combine_fields(self.error, other.error),
+            base64_image=combine_fields(self.base64_image, other.base64_image, False),
+            system=combine_fields(self.system, other.system),
+        )
+
+    def replace(self, **kwargs):
+        """Returns a new ToolResult with the given fields replaced."""
+        return replace(self, **kwargs)
+
+
+class CLIResult(ToolResult):
+    """A ToolResult that can be rendered as a CLI output."""
+
+
+class ToolFailure(ToolResult):
+    """A ToolResult that represents a failure."""
+
+
+class ToolError(Exception):
+    """Raised when a tool encounters an error."""
+
+    def __init__(self, message):
+        self.message = message

--- a/sentinelbot/sentinel/tools/bash.py
+++ b/sentinelbot/sentinel/tools/bash.py
@@ -1,0 +1,147 @@
+import asyncio
+import os
+from typing import Any, Literal
+
+from .base import BaseAnthropicTool, CLIResult, ToolError, ToolResult
+
+
+class _BashSession:
+    """A session of a bash shell."""
+
+    _started: bool
+    _process: asyncio.subprocess.Process
+
+    command: str = "/bin/bash"
+    _output_delay: float = 0.2  # seconds
+    _timeout: float = 120.0  # seconds
+    _sentinel: str = "<<exit>>"
+
+    def __init__(self):
+        self._started = False
+        self._timed_out = False
+
+    async def start(self):
+        if self._started:
+            return
+
+        self._process = await asyncio.create_subprocess_shell(
+            self.command,
+            preexec_fn=os.setsid,
+            shell=True,
+            bufsize=0,
+            stdin=asyncio.subprocess.PIPE,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+
+        self._started = True
+
+    def stop(self):
+        """Terminate the bash shell."""
+        if not self._started:
+            raise ToolError("Session has not started.")
+        if self._process.returncode is not None:
+            return
+        self._process.terminate()
+
+    async def run(self, command: str):
+        """Execute a command in the bash shell."""
+        if not self._started:
+            raise ToolError("Session has not started.")
+        if self._process.returncode is not None:
+            return ToolResult(
+                system="tool must be restarted",
+                error=f"bash has exited with returncode {self._process.returncode}",
+            )
+        if self._timed_out:
+            raise ToolError(
+                f"timed out: bash has not returned in {self._timeout} seconds and must be restarted",
+            )
+
+        # we know these are not None because we created the process with PIPEs
+        assert self._process.stdin
+        assert self._process.stdout
+        assert self._process.stderr
+
+        # send command to the process
+        self._process.stdin.write(
+            command.encode() + f"; echo '{self._sentinel}'\n".encode()
+        )
+        await self._process.stdin.drain()
+
+        # read output from the process, until the sentinel is found
+        try:
+            async with asyncio.timeout(self._timeout):
+                while True:
+                    await asyncio.sleep(self._output_delay)
+                    # if we read directly from stdout/stderr, it will wait forever for
+                    # EOF. use the StreamReader buffer directly instead.
+                    output = self._process.stdout._buffer.decode()  # pyright: ignore[reportAttributeAccessIssue]
+                    if self._sentinel in output:
+                        # strip the sentinel and break
+                        output = output[: output.index(self._sentinel)]
+                        break
+        except asyncio.TimeoutError:
+            self._timed_out = True
+            raise ToolError(
+                f"timed out: bash has not returned in {self._timeout} seconds and must be restarted",
+            ) from None
+
+        if output.endswith("\n"):
+            output = output[:-1]
+
+        error = self._process.stderr._buffer.decode()  # pyright: ignore[reportAttributeAccessIssue]
+        if error.endswith("\n"):
+            error = error[:-1]
+
+        # clear the buffers so that the next output can be read correctly
+        self._process.stdout._buffer.clear()  # pyright: ignore[reportAttributeAccessIssue]
+        self._process.stderr._buffer.clear()  # pyright: ignore[reportAttributeAccessIssue]
+
+        return CLIResult(output=output, error=error)
+
+
+class BashTool20250124(BaseAnthropicTool):
+    """
+    A tool that allows the agent to run bash commands.
+    The tool parameters are defined by Anthropic and are not editable.
+    """
+
+    _session: _BashSession | None
+
+    api_type: Literal["bash_20250124"] = "bash_20250124"
+    name: Literal["bash"] = "bash"
+
+    def __init__(self):
+        self._session = None
+        super().__init__()
+
+    def to_params(self) -> Any:
+        return {
+            "type": self.api_type,
+            "name": self.name,
+        }
+
+    async def __call__(
+        self, command: str | None = None, restart: bool = False, **kwargs
+    ):
+        if restart:
+            if self._session:
+                self._session.stop()
+            self._session = _BashSession()
+            await self._session.start()
+
+            return ToolResult(system="tool has been restarted.")
+
+        if self._session is None:
+            self._session = _BashSession()
+            await self._session.start()
+
+        if command is not None:
+            return await self._session.run(command)
+
+        raise ToolError("no command provided.")
+
+
+class BashTool20241022(BashTool20250124):
+    api_type: Literal["bash_20250124"] = "bash_20250124"  # pyright: ignore[reportIncompatibleVariableOverride]

--- a/sentinelbot/sentinel/tools/collection.py
+++ b/sentinelbot/sentinel/tools/collection.py
@@ -1,0 +1,34 @@
+from typing import Any, cast
+
+from anthropic.types.beta import BetaToolUnionParam
+
+from .base import (
+    BaseAnthropicTool,
+    ToolError,
+    ToolFailure,
+    ToolResult,
+)
+
+
+class ToolCollection:
+    """A collection of anthropic-defined tools."""
+
+    def __init__(self, *tools: BaseAnthropicTool):
+        self.tools = tools
+        self.tool_map = {
+            cast(dict[str, Any], tool.to_params())["name"]: tool for tool in tools
+        }
+
+    def to_params(
+        self,
+    ) -> list[BetaToolUnionParam]:
+        return [tool.to_params() for tool in self.tools]
+
+    async def run(self, *, name: str, tool_input: dict[str, Any]) -> ToolResult:
+        tool = self.tool_map.get(name)
+        if not tool:
+            return ToolFailure(error=f"Tool {name} is invalid")
+        try:
+            return await tool(**tool_input)
+        except ToolError as e:
+            return ToolFailure(error=e.message)

--- a/sentinelbot/sentinel/tools/groups.py
+++ b/sentinelbot/sentinel/tools/groups.py
@@ -1,0 +1,31 @@
+from dataclasses import dataclass
+from typing import Literal
+
+from .base import BaseAnthropicTool
+from .bash import BashTool20250124
+from .playwright_tool import PlaywrightComputerTool
+
+ToolVersion = Literal[
+    "sentinel_playwright",
+]
+BetaFlag = Literal[
+    "computer-use-2025-01-24",
+]
+
+
+@dataclass(frozen=True, kw_only=True)
+class ToolGroup:
+    version: ToolVersion
+    tools: list[type[BaseAnthropicTool]]
+    beta_flag: BetaFlag | None = None
+
+
+TOOL_GROUPS: list[ToolGroup] = [
+    ToolGroup(
+        version="sentinel_playwright",
+        tools=[PlaywrightComputerTool, BashTool20250124],
+        beta_flag="computer-use-2025-01-24",
+    ),
+]
+
+TOOL_GROUPS_BY_VERSION = {tool_group.version: tool_group for tool_group in TOOL_GROUPS}

--- a/sentinelbot/sentinel/tools/playwright_tool.py
+++ b/sentinelbot/sentinel/tools/playwright_tool.py
@@ -1,0 +1,881 @@
+import asyncio
+import base64
+import logging
+import os
+from typing import Any, Literal, cast, get_args
+
+from playwright.async_api import async_playwright, Browser, BrowserContext, Page, Playwright
+
+from anthropic.types.beta import BetaToolUnionParam
+
+from .base import BaseAnthropicTool, ToolError, ToolResult
+
+logger = logging.getLogger(__name__)
+
+# ── Action types (must match computer_20250124 schema exactly) ──────────
+
+Action = Literal[
+    "key",
+    "type",
+    "mouse_move",
+    "left_click",
+    "left_click_drag",
+    "right_click",
+    "middle_click",
+    "double_click",
+    "triple_click",
+    "screenshot",
+    "cursor_position",
+    "left_mouse_down",
+    "left_mouse_up",
+    "scroll",
+    "hold_key",
+    "wait",
+]
+
+ScrollDirection = Literal["up", "down", "left", "right"]
+
+# ── Device profiles ─────────────────────────────────────────────────────
+
+DEVICE_PROFILES: dict[str, dict[str, Any]] = {
+    "iphone_se": {
+        "viewport": {"width": 375, "height": 667},
+        "user_agent": (
+            "Mozilla/5.0 (iPhone; CPU iPhone OS 15_0 like Mac OS X) "
+            "AppleWebKit/605.1.15 (KHTML, like Gecko) Version/15.0 Mobile/15E148 Safari/604.1"
+        ),
+        "device_scale_factor": 2,
+        "is_mobile": True,
+        "has_touch": True,
+    },
+    "iphone_14": {
+        "viewport": {"width": 390, "height": 844},
+        "user_agent": (
+            "Mozilla/5.0 (iPhone; CPU iPhone OS 16_0 like Mac OS X) "
+            "AppleWebKit/605.1.15 (KHTML, like Gecko) Version/16.0 Mobile/15E148 Safari/604.1"
+        ),
+        "device_scale_factor": 3,
+        "is_mobile": True,
+        "has_touch": True,
+    },
+    "iphone_15_pro": {
+        "viewport": {"width": 393, "height": 852},
+        "user_agent": (
+            "Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) "
+            "AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Mobile/15E148 Safari/604.1"
+        ),
+        "device_scale_factor": 3,
+        "is_mobile": True,
+        "has_touch": True,
+    },
+    "pixel_7": {
+        "viewport": {"width": 412, "height": 915},
+        "user_agent": (
+            "Mozilla/5.0 (Linux; Android 13; Pixel 7) "
+            "AppleWebKit/537.36 (KHTML, like Gecko) Chrome/116.0.0.0 Mobile Safari/537.36"
+        ),
+        "device_scale_factor": 2.625,
+        "is_mobile": True,
+        "has_touch": True,
+    },
+    "galaxy_s8": {
+        "viewport": {"width": 360, "height": 740},
+        "user_agent": (
+            "Mozilla/5.0 (Linux; Android 9; SM-G950F) "
+            "AppleWebKit/537.36 (KHTML, like Gecko) Chrome/116.0.0.0 Mobile Safari/537.36"
+        ),
+        "device_scale_factor": 3,
+        "is_mobile": True,
+        "has_touch": True,
+    },
+    "galaxy_s23": {
+        "viewport": {"width": 360, "height": 780},
+        "user_agent": (
+            "Mozilla/5.0 (Linux; Android 13; SM-S911B) "
+            "AppleWebKit/537.36 (KHTML, like Gecko) Chrome/116.0.0.0 Mobile Safari/537.36"
+        ),
+        "device_scale_factor": 3,
+        "is_mobile": True,
+        "has_touch": True,
+    },
+    "desktop": {
+        "viewport": {"width": 1280, "height": 800},
+        "user_agent": (
+            "Mozilla/5.0 (X11; Linux x86_64) "
+            "AppleWebKit/537.36 (KHTML, like Gecko) Chrome/116.0.0.0 Safari/537.36"
+        ),
+        "device_scale_factor": 1,
+        "is_mobile": False,
+        "has_touch": False,
+    },
+    "desktop_1440": {
+        "viewport": {"width": 1440, "height": 900},
+        "user_agent": (
+            "Mozilla/5.0 (X11; Linux x86_64) "
+            "AppleWebKit/537.36 (KHTML, like Gecko) Chrome/116.0.0.0 Safari/537.36"
+        ),
+        "device_scale_factor": 1,
+        "is_mobile": False,
+        "has_touch": False,
+    },
+    "desktop_1920": {
+        "viewport": {"width": 1920, "height": 1080},
+        "user_agent": (
+            "Mozilla/5.0 (X11; Linux x86_64) "
+            "AppleWebKit/537.36 (KHTML, like Gecko) Chrome/116.0.0.0 Safari/537.36"
+        ),
+        "device_scale_factor": 1,
+        "is_mobile": False,
+        "has_touch": False,
+    },
+}
+
+# ── Network throttling profiles ─────────────────────────────────────────
+
+NETWORK_PROFILES: dict[str, dict[str, Any]] = {
+    "wifi": {},          # No throttling
+    "4g": {
+        "offline": False,
+        "download_throughput": 9000 * 1024 // 8,        # 9 Mbps
+        "upload_throughput": 9000 * 1024 // 8,           # 9 Mbps
+        "latency": 80,   # ms
+    },
+    "fast_3g": {
+        "offline": False,
+        "download_throughput": 1600 * 1024 // 8,        # 1.6 Mbps
+        "upload_throughput": 750 * 1024 // 8,            # 750 Kbps
+        "latency": 150,  # ms
+    },
+    "slow_3g": {
+        "offline": False,
+        "download_throughput": 400 * 1024 // 8,         # 400 Kbps
+        "upload_throughput": 400 * 1024 // 8,
+        "latency": 400,  # ms
+    },
+    "high_latency": {
+        "offline": False,
+        "download_throughput": 2000 * 1024 // 8,        # 2 Mbps
+        "upload_throughput": 2000 * 1024 // 8,
+        "latency": 800,  # ms
+    },
+    "offline": {
+        "offline": True,
+        "download_throughput": 0,
+        "upload_throughput": 0,
+        "latency": 0,
+    },
+}
+
+# ── Key name mapping (xdotool key names → Playwright key names) ─────────
+
+XDOTOOL_TO_PLAYWRIGHT_KEYS: dict[str, str] = {
+    "Return": "Enter",
+    "BackSpace": "Backspace",
+    "Tab": "Tab",
+    "Escape": "Escape",
+    "space": " ",
+    "Delete": "Delete",
+    "Home": "Home",
+    "End": "End",
+    "Page_Up": "PageUp",
+    "Page_Down": "PageDown",
+    "Up": "ArrowUp",
+    "Down": "ArrowDown",
+    "Left": "ArrowLeft",
+    "Right": "ArrowRight",
+    "super": "Meta",
+    "Super_L": "Meta",
+    "Super_R": "Meta",
+    "Control_L": "Control",
+    "Control_R": "Control",
+    "Alt_L": "Alt",
+    "Alt_R": "Alt",
+    "Shift_L": "Shift",
+    "Shift_R": "Shift",
+    "ctrl": "Control",
+    "alt": "Alt",
+    "shift": "Shift",
+    "cmd": "Meta",
+    "command": "Meta",
+    "meta": "Meta",
+    "enter": "Enter",
+    "return": "Enter",
+    "backspace": "Backspace",
+    "escape": "Escape",
+    "esc": "Escape",
+    "delete": "Delete",
+    "tab": "Tab",
+    "arrowup": "ArrowUp",
+    "arrowdown": "ArrowDown",
+    "arrowleft": "ArrowLeft",
+    "arrowright": "ArrowRight",
+    "pageup": "PageUp",
+    "pagedown": "PageDown",
+    "home": "Home",
+    "end": "End",
+}
+
+
+def _translate_key(key_name: str) -> str:
+    """Translate xdotool-style key names to Playwright key names.
+
+    Handles compound key expressions like 'ctrl+a' → 'Control+a'
+    and single keys like 'Return' → 'Enter'.
+    """
+    if "+" in key_name:
+        parts = key_name.split("+")
+        return "+".join(XDOTOOL_TO_PLAYWRIGHT_KEYS.get(p.strip(), p.strip()) for p in parts)
+    return XDOTOOL_TO_PLAYWRIGHT_KEYS.get(key_name, key_name)
+
+
+class PlaywrightComputerTool(BaseAnthropicTool):
+    """
+    A Playwright-based ComputerTool that emulates a mobile browser.
+
+    Implements the same interface as ComputerTool20250124 (api_type="computer_20250124")
+    so Claude sends the same actions, but executes them via Playwright instead of xdotool.
+
+    The browser runs headless=False into the X11 display so it's visible in VNC.
+    """
+
+    name: Literal["computer"] = "computer"
+    api_type: Literal["computer_20250124"] = "computer_20250124"
+
+    def __init__(
+        self,
+        *,
+        device_profile: str = "iphone_14",
+        network_profile: str = "wifi",
+        device_profile_dict: dict | None = None,
+        network_profile_dict: dict | None = None,
+        target_url: str | None = None,
+        locale: str = "en-US",
+        video_dir: str | None = None,
+    ):
+        super().__init__()
+        self._device_profile_name = device_profile
+        # Use explicit dict if provided (e.g. from Supabase), else fall back to hardcoded
+        self._device = device_profile_dict or DEVICE_PROFILES.get(device_profile, DEVICE_PROFILES["iphone_14"])
+        self._network_profile_name = network_profile
+        self._network = network_profile_dict or NETWORK_PROFILES.get(network_profile, NETWORK_PROFILES["wifi"])
+        self._target_url = target_url
+        self._locale = locale
+        self._video_dir = video_dir
+
+        # Playwright objects (initialized lazily)
+        self._playwright: Playwright | None = None
+        self._browser: Browser | None = None
+        self._context: BrowserContext | None = None
+        self._page: Page | None = None
+
+        # Console log capture
+        self._console_errors: list[str] = []
+
+        # Performance metrics collected per page navigation
+        self._perf_metrics: list[dict[str, Any]] = []
+
+        # Accessibility violations collected via axe-core
+        self._a11y_violations: list[dict[str, Any]] = []
+
+        # Screenshot delay (same pattern as original ComputerTool)
+        self._screenshot_delay = 1.0
+
+        # Viewport dimensions (what Claude sees as the coordinate space)
+        self._width = self._device["viewport"]["width"]
+        self._height = self._device["viewport"]["height"]
+
+        # Track cursor position for cursor_position action
+        self._cursor_x = 0
+        self._cursor_y = 0
+
+    # ── Lifecycle ───────────────────────────────────────────────────────
+
+    async def _ensure_browser(self):
+        """Lazily initialize the Playwright browser, context, and page."""
+        if self._page is not None:
+            return
+
+        self._playwright = await async_playwright().start()
+        self._browser = await self._playwright.chromium.launch(
+            headless=True,
+            args=[
+                "--no-sandbox",
+                "--disable-gpu",
+                "--disable-dev-shm-usage",
+            ],
+        )
+
+        # Create context with device emulation (and optional video recording)
+        context_opts: dict[str, Any] = {
+            "viewport": self._device["viewport"],
+            "user_agent": self._device["user_agent"],
+            "device_scale_factor": self._device["device_scale_factor"],
+            "is_mobile": self._device["is_mobile"],
+            "has_touch": self._device["has_touch"],
+            "locale": self._locale,
+        }
+        if self._video_dir:
+            import os as _os
+            _os.makedirs(self._video_dir, exist_ok=True)
+            context_opts["record_video_dir"] = self._video_dir
+
+        self._context = await self._browser.new_context(**context_opts)
+
+        self._page = self._context.pages[0] if self._context.pages else await self._context.new_page()
+
+        # Wire up console error capture
+        self._page.on("console", lambda msg: (
+            self._console_errors.append(f"[{msg.type}] {msg.text}")
+            if msg.type in ("error", "warning") else None
+        ))
+        self._page.on("pageerror", lambda err: (
+            self._console_errors.append(f"[PAGE_ERROR] {err}")
+        ))
+
+        # Apply network throttling
+        if self._network and self._network.get("latency") is not None:
+            try:
+                cdp = await self._page.context.new_cdp_session(self._page)
+                await cdp.send("Network.emulateNetworkConditions", {
+                    "offline": self._network.get("offline", False),
+                    "downloadThroughput": self._network.get("download_throughput", -1),
+                    "uploadThroughput": self._network.get("upload_throughput", -1),
+                    "latency": self._network.get("latency", 0),
+                })
+            except Exception as e:
+                logger.warning(f"Failed to set network throttling: {e}")
+
+        # Navigate to target URL if provided
+        if self._target_url:
+            url = self._target_url
+            if not url.startswith(("http://", "https://")):
+                url = "https://" + url
+            try:
+                await self._page.goto(url, wait_until="domcontentloaded", timeout=30000)
+            except Exception as e:
+                logger.warning(f"Failed to navigate to {self._target_url}: {e}")
+
+    async def close(self):
+        """Clean up Playwright resources. Closes context first to finalize video recording."""
+        if self._context:
+            await self._context.close()
+        if self._browser:
+            await self._browser.close()
+        if self._playwright:
+            await self._playwright.stop()
+        self._page = None
+        self._context = None
+        self._browser = None
+        self._playwright = None
+
+    # ── Tool interface ──────────────────────────────────────────────────
+
+    def to_params(self) -> BetaToolUnionParam:
+        """Return tool parameters for the Claude API.
+
+        Uses the Playwright viewport dimensions as the coordinate space.
+        Claude will send coordinates in this space and we use them directly.
+        """
+        return cast(
+            BetaToolUnionParam,
+            {
+                "name": self.name,
+                "type": self.api_type,
+                "display_width_px": self._width,
+                "display_height_px": self._height,
+            },
+        )
+
+    async def __call__(
+        self,
+        *,
+        action: Action,
+        text: str | None = None,
+        coordinate: tuple[int, int] | None = None,
+        start_coordinate: tuple[int, int] | None = None,
+        scroll_direction: ScrollDirection | None = None,
+        scroll_amount: int | None = None,
+        duration: int | float | None = None,
+        key: str | None = None,
+        **kwargs,
+    ) -> ToolResult:
+        """Execute an action via Playwright.
+
+        This method handles all the same actions as ComputerTool20250124:
+        left_click, right_click, double_click, triple_click, middle_click,
+        mouse_move, left_click_drag, left_mouse_down, left_mouse_up,
+        key, type, scroll, screenshot, cursor_position, hold_key, wait.
+        """
+        await self._ensure_browser()
+        assert self._page is not None
+
+        try:
+            return await self._dispatch_action(
+                action=action,
+                text=text,
+                coordinate=coordinate,
+                start_coordinate=start_coordinate,
+                scroll_direction=scroll_direction,
+                scroll_amount=scroll_amount,
+                duration=duration,
+                key=key,
+            )
+        except ToolError:
+            raise
+        except Exception as e:
+            logger.error(f"PlaywrightComputerTool error: {action=} {e}", exc_info=True)
+            raise ToolError(f"Action '{action}' failed: {str(e)}")
+
+    async def _dispatch_action(
+        self,
+        *,
+        action: Action,
+        text: str | None,
+        coordinate: tuple[int, int] | None,
+        start_coordinate: tuple[int, int] | None,
+        scroll_direction: ScrollDirection | None,
+        scroll_amount: int | None,
+        duration: int | float | None,
+        key: str | None,
+    ) -> ToolResult:
+        assert self._page is not None
+
+        # ── Screenshot ──────────────────────────────────────────────
+        if action == "screenshot":
+            return await self._take_screenshot()
+
+        # ── Cursor position ─────────────────────────────────────────
+        if action == "cursor_position":
+            return ToolResult(output=f"X={self._cursor_x},Y={self._cursor_y}")
+
+        # ── Click actions ───────────────────────────────────────────
+        if action in ("left_click", "right_click", "middle_click", "double_click", "triple_click"):
+            if text is not None:
+                raise ToolError(f"text is not accepted for {action}")
+
+            x, y = self._validate_coordinate(coordinate, required=False)
+
+            # Move to coordinate if given
+            if coordinate is not None:
+                await self._page.mouse.move(x, y)
+                self._cursor_x, self._cursor_y = x, y
+
+            button = "right" if action == "right_click" else "middle" if action == "middle_click" else "left"
+            click_count = 1
+            if action == "double_click":
+                click_count = 2
+            elif action == "triple_click":
+                click_count = 3
+
+            # Hold modifier key if specified
+            if key:
+                pw_key = _translate_key(key)
+                await self._page.keyboard.down(pw_key)
+
+            await self._page.mouse.click(self._cursor_x, self._cursor_y, button=button, click_count=click_count)
+
+            if key:
+                pw_key = _translate_key(key)
+                await self._page.keyboard.up(pw_key)
+
+            await asyncio.sleep(self._screenshot_delay)
+            return await self._take_screenshot()
+
+        # ── Mouse move ──────────────────────────────────────────────
+        if action == "mouse_move":
+            if coordinate is None:
+                raise ToolError("coordinate is required for mouse_move")
+            x, y = self._validate_coordinate(coordinate)
+            await self._page.mouse.move(x, y)
+            self._cursor_x, self._cursor_y = x, y
+            await asyncio.sleep(self._screenshot_delay)
+            return await self._take_screenshot()
+
+        # ── Left click drag ─────────────────────────────────────────
+        if action == "left_click_drag":
+            if coordinate is None:
+                raise ToolError("coordinate is required for left_click_drag")
+            if start_coordinate is None:
+                raise ToolError("start_coordinate is required for left_click_drag")
+            if text is not None:
+                raise ToolError("text is not accepted for left_click_drag")
+
+            sx, sy = self._validate_coordinate(start_coordinate)
+            ex, ey = self._validate_coordinate(coordinate)
+
+            await self._page.mouse.move(sx, sy)
+            await self._page.mouse.down()
+            await self._page.mouse.move(ex, ey, steps=10)
+            await self._page.mouse.up()
+            self._cursor_x, self._cursor_y = ex, ey
+
+            await asyncio.sleep(self._screenshot_delay)
+            return await self._take_screenshot()
+
+        # ── Mouse down / up ─────────────────────────────────────────
+        if action == "left_mouse_down":
+            if coordinate is not None:
+                raise ToolError("coordinate is not accepted for left_mouse_down")
+            await self._page.mouse.down()
+            await asyncio.sleep(self._screenshot_delay)
+            return await self._take_screenshot()
+
+        if action == "left_mouse_up":
+            if coordinate is not None:
+                raise ToolError("coordinate is not accepted for left_mouse_up")
+            await self._page.mouse.up()
+            await asyncio.sleep(self._screenshot_delay)
+            return await self._take_screenshot()
+
+        # ── Key press ───────────────────────────────────────────────
+        if action == "key":
+            if text is None:
+                raise ToolError("text is required for key")
+            if coordinate is not None:
+                raise ToolError("coordinate is not accepted for key")
+
+            # Handle space-separated repeated keys (e.g. "Backspace Backspace Backspace")
+            # and single keys or combo keys (e.g. "Control+a")
+            keys = text.split(" ") if "+" not in text and " " in text else [text]
+            for k in keys:
+                pw_key = _translate_key(k.strip())
+                if pw_key:
+                    await self._page.keyboard.press(pw_key)
+
+            await asyncio.sleep(self._screenshot_delay)
+            return await self._take_screenshot()
+
+        # ── Type text ───────────────────────────────────────────────
+        if action == "type":
+            if text is None:
+                raise ToolError("text is required for type")
+            if coordinate is not None:
+                raise ToolError("coordinate is not accepted for type")
+
+            await self._page.keyboard.type(text, delay=12)
+
+            await asyncio.sleep(self._screenshot_delay)
+            return await self._take_screenshot()
+
+        # ── Scroll ──────────────────────────────────────────────────
+        if action == "scroll":
+            if scroll_direction is None or scroll_direction not in get_args(ScrollDirection):
+                raise ToolError(f"scroll_direction must be 'up', 'down', 'left', or 'right'")
+            if not isinstance(scroll_amount, int) or scroll_amount < 0:
+                raise ToolError(f"scroll_amount must be a non-negative int")
+
+            # Move to coordinate first if given
+            if coordinate is not None:
+                x, y = self._validate_coordinate(coordinate)
+                await self._page.mouse.move(x, y)
+                self._cursor_x, self._cursor_y = x, y
+
+            # Hold modifier key if specified
+            if text:
+                pw_key = _translate_key(text)
+                await self._page.keyboard.down(pw_key)
+
+            # Playwright scroll: mouse.wheel(delta_x, delta_y)
+            # Each "click" of scroll = ~100 pixels
+            pixels_per_click = 100
+            delta = scroll_amount * pixels_per_click
+
+            if scroll_direction == "up":
+                await self._page.mouse.wheel(0, -delta)
+            elif scroll_direction == "down":
+                await self._page.mouse.wheel(0, delta)
+            elif scroll_direction == "left":
+                await self._page.mouse.wheel(-delta, 0)
+            elif scroll_direction == "right":
+                await self._page.mouse.wheel(delta, 0)
+
+            if text:
+                pw_key = _translate_key(text)
+                await self._page.keyboard.up(pw_key)
+
+            await asyncio.sleep(self._screenshot_delay)
+            return await self._take_screenshot()
+
+        # ── Hold key ────────────────────────────────────────────────
+        if action == "hold_key":
+            if text is None:
+                raise ToolError("text is required for hold_key")
+            if duration is None or not isinstance(duration, (int, float)):
+                raise ToolError("duration must be a number")
+            if duration < 0:
+                raise ToolError("duration must be non-negative")
+            if duration > 100:
+                raise ToolError("duration is too long")
+
+            pw_key = _translate_key(text)
+            await self._page.keyboard.down(pw_key)
+            await asyncio.sleep(duration)
+            await self._page.keyboard.up(pw_key)
+
+            return await self._take_screenshot()
+
+        # ── Wait ────────────────────────────────────────────────────
+        if action == "wait":
+            if duration is None or not isinstance(duration, (int, float)):
+                raise ToolError("duration must be a number")
+            if duration < 0:
+                raise ToolError("duration must be non-negative")
+            if duration > 100:
+                raise ToolError("duration is too long")
+
+            await asyncio.sleep(duration)
+            return await self._take_screenshot()
+
+        raise ToolError(f"Invalid action: {action}")
+
+    # ── Helpers ─────────────────────────────────────────────────────
+
+    async def _take_screenshot(self) -> ToolResult:
+        """Capture a screenshot of the current page via Playwright.
+        
+        Resizes to fit within MAX_SCREENSHOT_DIMENSION to avoid Anthropic's
+        image size limit for multi-image requests (2000px per dimension).
+        """
+        MAX_SCREENSHOT_DIMENSION = 1568  # Safe margin under 2000px API limit
+
+        assert self._page is not None
+        try:
+            png_bytes = await self._page.screenshot(type="png")
+
+            # Resize if any dimension exceeds the limit
+            from PIL import Image
+            import io
+
+            img = Image.open(io.BytesIO(png_bytes))
+            w, h = img.size
+            if w > MAX_SCREENSHOT_DIMENSION or h > MAX_SCREENSHOT_DIMENSION:
+                scale = min(MAX_SCREENSHOT_DIMENSION / w, MAX_SCREENSHOT_DIMENSION / h)
+                new_w, new_h = int(w * scale), int(h * scale)
+                img = img.resize((new_w, new_h), Image.LANCZOS)
+                buf = io.BytesIO()
+                img.save(buf, format="PNG")
+                png_bytes = buf.getvalue()
+
+            b64 = base64.b64encode(png_bytes).decode("utf-8")
+            return ToolResult(base64_image=b64)
+        except Exception as e:
+            raise ToolError(f"Failed to take screenshot: {e}")
+
+    def _validate_coordinate(
+        self, coordinate: tuple[int, int] | None, required: bool = True
+    ) -> tuple[int, int]:
+        """Validate and return coordinates. No scaling needed since viewport = coordinate space."""
+        if coordinate is None:
+            if required:
+                raise ToolError("coordinate is required")
+            return self._cursor_x, self._cursor_y
+
+        if not isinstance(coordinate, (list, tuple)) or len(coordinate) != 2:
+            raise ToolError(f"{coordinate} must be a tuple of length 2")
+        if not all(isinstance(i, (int, float)) and i >= 0 for i in coordinate):
+            raise ToolError(f"{coordinate} must be a tuple of non-negative numbers")
+
+        x, y = int(coordinate[0]), int(coordinate[1])
+
+        # Clamp to viewport (don't error, some slight overflows are normal)
+        x = min(x, self._width - 1)
+        y = min(y, self._height - 1)
+
+        return x, y
+
+    # ── Extra methods for SentinelBot integration ───────────────────
+
+    @property
+    def page(self) -> Page | None:
+        """Direct access to the Playwright page for advanced use (console logs, network, etc.)."""
+        return self._page
+
+    @property
+    def current_url(self) -> str | None:
+        """Get the current page URL."""
+        return self._page.url if self._page else None
+
+    async def get_console_errors(self) -> list[str]:
+        """Return captured console errors and warnings from the page."""
+        return list(self._console_errors)
+
+    def clear_console_errors(self):
+        """Clear the captured console errors list."""
+        self._console_errors.clear()
+
+    async def navigate(self, url: str, timeout: int = 30000):
+        """Navigate to a URL directly (useful for SentinelBot setup before loop starts)."""
+        if not url.startswith(("http://", "https://")):
+            url = "https://" + url
+        await self._ensure_browser()
+        assert self._page is not None
+        await self._page.goto(url, wait_until="domcontentloaded", timeout=timeout)
+
+    # ── Performance Metrics Collection ──────────────────────────────
+
+    async def collect_perf_metrics(self, step: int | None = None) -> dict[str, Any] | None:
+        """Collect Core Web Vitals and resource timing from the current page.
+
+        Injects JavaScript to gather:
+        - LCP (Largest Contentful Paint)
+        - CLS (Cumulative Layout Shift)
+        - TTFB (Time to First Byte)
+        - FCP (First Contentful Paint)
+        - DOMContentLoaded timing
+        - Resource count and total transfer size
+
+        Returns the metrics dict, or None if collection fails.
+        """
+        if not self._page:
+            return None
+
+        try:
+            metrics = await self._page.evaluate("""
+            () => {
+                const result = {};
+
+                // Navigation timing
+                const nav = performance.getEntriesByType('navigation');
+                if (nav.length > 0) {
+                    const n = nav[0];
+                    result.ttfb_ms = n.responseStart - n.requestStart;
+                    result.dom_content_loaded_ms = n.domContentLoadedEventEnd - n.startTime;
+                }
+
+                // FCP (First Contentful Paint)
+                const fcp = performance.getEntriesByName('first-contentful-paint');
+                if (fcp.length > 0) {
+                    result.fcp_ms = fcp[0].startTime;
+                }
+
+                // LCP (Largest Contentful Paint) — uses PerformanceObserver entries
+                const lcpEntries = performance.getEntriesByType('largest-contentful-paint');
+                if (lcpEntries.length > 0) {
+                    result.lcp_ms = lcpEntries[lcpEntries.length - 1].startTime;
+                }
+
+                // CLS (Cumulative Layout Shift)
+                const clsEntries = performance.getEntriesByType('layout-shift');
+                if (clsEntries.length > 0) {
+                    let clsScore = 0;
+                    clsEntries.forEach(entry => {
+                        if (!entry.hadRecentInput) {
+                            clsScore += entry.value;
+                        }
+                    });
+                    result.cls = clsScore;
+                }
+
+                // Resource stats
+                const resources = performance.getEntriesByType('resource');
+                result.resource_count = resources.length;
+                let totalBytes = 0;
+                resources.forEach(r => {
+                    totalBytes += r.transferSize || 0;
+                });
+                result.total_transfer_kb = totalBytes / 1024;
+
+                return result;
+            }
+            """)
+
+            if metrics:
+                metrics["url"] = self._page.url
+                if step is not None:
+                    metrics["step"] = step
+                self._perf_metrics.append(metrics)
+                logger.info(
+                    f"Perf metrics for {self._page.url}: "
+                    f"LCP={metrics.get('lcp_ms', '?')}ms, "
+                    f"CLS={metrics.get('cls', '?')}, "
+                    f"TTFB={metrics.get('ttfb_ms', '?')}ms, "
+                    f"FCP={metrics.get('fcp_ms', '?')}ms"
+                )
+                return metrics
+        except Exception as e:
+            logger.warning(f"Failed to collect perf metrics: {e}")
+        return None
+
+    def get_perf_metrics(self) -> list[dict[str, Any]]:
+        """Return all collected performance metrics."""
+        return list(self._perf_metrics)
+
+    # ── Accessibility Auditing (axe-core) ───────────────────────────
+
+    async def run_accessibility_audit(
+        self,
+        standard: str = "wcag21aa",
+    ) -> list[dict[str, Any]]:
+        """Run an axe-core accessibility audit on the current page.
+
+        Injects axe-core from CDN, runs axe.run() with the specified WCAG standard,
+        and returns the list of violations.
+
+        Args:
+            standard: WCAG standard tag — one of 'wcag2a', 'wcag2aa', 'wcag21a',
+                      'wcag21aa', 'wcag22aa', 'best-practice'.
+                      Default is 'wcag21aa' (WCAG 2.1 AA).
+
+        Returns:
+            List of violation dicts, each with: id, impact, description, help,
+            helpUrl, nodes (list of affected elements).
+        """
+        if not self._page:
+            return []
+
+        try:
+            # Inject axe-core if not already present
+            axe_loaded = await self._page.evaluate("typeof window.axe !== 'undefined'")
+            if not axe_loaded:
+                await self._page.add_script_tag(
+                    url="https://cdnjs.cloudflare.com/ajax/libs/axe-core/4.9.1/axe.min.js"
+                )
+                # Wait for axe to become available
+                await self._page.wait_for_function(
+                    "typeof window.axe !== 'undefined'",
+                    timeout=10000,
+                )
+
+            # Run the audit with the specified standard
+            violations = await self._page.evaluate(f"""
+            async () => {{
+                const results = await axe.run(document, {{
+                    runOnly: {{
+                        type: 'tag',
+                        values: ['{standard}']
+                    }}
+                }});
+                return results.violations.map(v => ({{
+                    id: v.id,
+                    impact: v.impact,
+                    description: v.description,
+                    help: v.help,
+                    helpUrl: v.helpUrl,
+                    tags: v.tags,
+                    nodes: v.nodes.slice(0, 5).map(n => ({{
+                        html: n.html.substring(0, 200),
+                        target: n.target,
+                        failureSummary: n.failureSummary
+                    }}))
+                }}));
+            }}
+            """)
+
+            if violations:
+                self._a11y_violations.extend(violations)
+                logger.info(
+                    f"Accessibility audit on {self._page.url}: "
+                    f"{len(violations)} violations found"
+                )
+            else:
+                logger.info(f"Accessibility audit on {self._page.url}: no violations")
+
+            return violations or []
+
+        except Exception as e:
+            logger.warning(f"Accessibility audit failed: {e}")
+            return []
+
+    def get_a11y_violations(self) -> list[dict[str, Any]]:
+        """Return all collected accessibility violations across all page audits."""
+        return list(self._a11y_violations)


### PR DESCRIPTION
Initial scaffold for SentinelBot: adds README, Dockerfile and image entrypoint, pip requirements, and the sentinel package. Implements Supabase client and DB modules (devices, evidence, issues, logs, perf, runs), an agentic sampling loop for Anthropic/Claude, a continuous scheduler, and Playwright/tool integration stubs. Bootstraps a FastAPI-based test runner with storage/upload helpers, issue similarity/frequency utilities, run logging, and utilities to persist screenshots/videos to Supabase. This commit provides the base architecture (Docker + local run instructions) for end-to-end QA testing with Playwright and Anthropic, plus Slack notification hooks and scheduler support.